### PR TITLE
fix(demo): add missing dependency greenlet to demo group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ demo = [
     "fastapi>=0.100.0",
     "uvicorn>=0.23.0",
     "aiosqlite>=0.19.0",
+    "greenlet>=3.3.2",
 ]
 mcp = [
     "mcp>=1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1111,6 +1111,7 @@ dependencies = [
 demo = [
     { name = "aiosqlite" },
     { name = "fastapi" },
+    { name = "greenlet" },
     { name = "uvicorn" },
 ]
 dev = [
@@ -1139,6 +1140,7 @@ requires-dist = [
     { name = "aiosqlite", marker = "extra == 'dev'", specifier = ">=0.19.0" },
     { name = "fastapi", marker = "extra == 'demo'", specifier = ">=0.100.0" },
     { name = "graphql-core", specifier = ">=3.2.0" },
+    { name = "greenlet", marker = "extra == 'demo'", specifier = ">=3.3.2" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },


### PR DESCRIPTION
Running the demo in a clean environment fails due to a missing dependency.

Add `greenlet` to the `demo` optional_dependency group