### PR TITLE
MCP API: align simple server factory naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ from nexusx import (
 
 # MCP (GraphQL)
 from nexusx.mcp import (
-    config_simple_mcp_server, # 单应用 MCP 服务
+    create_simple_mcp_server, # 单应用 MCP 服务
     create_mcp_server,        # 多应用 MCP 服务
     AppConfig,                # 应用配置
 )
@@ -116,6 +116,7 @@ from nexusx.mcp import (
 ## 开发命令
 
 ```bash
+./scripts/check-ci.sh                                       # 本地执行与 CI 一致的检查
 uv run pytest                                              # 运行测试
 uv run ruff check src/ tests/                              # Lint 检查
 uv run ruff check --fix src/ tests/                        # Lint 修复

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The concepts appear in this order because they mirror the delivery path from ide
 | Derived fields | `post_*` methods | Runs after all nested data is resolved |
 | Cross-layer data flow | `ExposeAs`, `SendTo`, `Collector` | Pass context down or aggregate values up |
 | Non-ORM relationships | `Relationship(...)` on entity | Same DataLoader infra, same auto-loading |
-| AI-ready APIs | `config_simple_mcp_server(base=...)` | Progressive-disclosure MCP tools |
+| AI-ready APIs | `create_simple_mcp_server(base=...)` | Progressive-disclosure MCP tools |
 | Business services | `UseCaseService` subclass with `@query`/`@mutation` methods | Auto-discovery, SDL introspection, MCP + FastAPI dual serving |
 | DTO query building | `build_dto_select(DtoClass, where=...)` | Builds SQL SELECT from DefineSubset DTO fields |
 | Auto REST routes | `create_use_case_router(config)` | Generates POST routes from UseCaseService methods |
@@ -455,9 +455,9 @@ Expose your SQLModel APIs to AI assistants with one function call.
 ### Simple MCP Server
 
 ```python
-from nexusx.mcp import config_simple_mcp_server
+from nexusx.mcp import create_simple_mcp_server
 
-mcp = config_simple_mcp_server(base=SQLModel, name="My API")
+mcp = create_simple_mcp_server(base=SQLModel, name="My API")
 mcp.run()  # stdio mode
 ```
 

--- a/README.md
+++ b/README.md
@@ -461,6 +461,12 @@ mcp = create_simple_mcp_server(base=SQLModel, name="My API")
 mcp.run()  # stdio mode
 ```
 
+Before pushing changes, run the same checks as CI:
+
+```bash
+./scripts/check-ci.sh
+```
+
 Tools: `get_schema()`, `graphql_query(query)`, `graphql_mutation(mutation)`.
 
 ### Multi-App MCP Server

--- a/demo/blog/mcp_server_simple.py
+++ b/demo/blog/mcp_server_simple.py
@@ -1,4 +1,4 @@
-"""Simple MCP server demo using config_simple_mcp_server.
+"""Simple MCP server demo using create_simple_mcp_server.
 
 This demo shows how to create a simplified MCP server for single-app scenarios
 with only 3 tools: get_schema, graphql_query, graphql_mutation.
@@ -17,7 +17,7 @@ from sqlmodel import SQLModel
 
 from demo.blog.database import async_session
 from nexusx import mutation, query
-from nexusx.mcp import config_simple_mcp_server
+from nexusx.mcp import create_simple_mcp_server
 
 
 # Define base entity
@@ -83,7 +83,7 @@ async def init_db():
 
 
 # Create simplified MCP server
-mcp = config_simple_mcp_server(
+mcp = create_simple_mcp_server(
     base=BaseEntity,
     name="Demo Simple Blog GraphQL MCP Server",
     desc="Blog system with users (simplified 3-tool version)",

--- a/docs/advanced/mcp_service.md
+++ b/docs/advanced/mcp_service.md
@@ -13,9 +13,9 @@ pip install nexusx[fastmcp]
 The simplest mode — pass a SQLModel base class:
 
 ```python
-from nexusx.mcp import config_simple_mcp_server
+from nexusx.mcp import create_simple_mcp_server
 
-mcp = config_simple_mcp_server(
+mcp = create_simple_mcp_server(
     base=SQLModel,
     name="My API",
 )
@@ -61,7 +61,7 @@ Multi-app tools:
 MCP services need a `session_factory` to execute database queries:
 
 ```python
-mcp = config_simple_mcp_server(
+mcp = create_simple_mcp_server(
     base=SQLModel,
     name="My API",
     session_factory=async_session,

--- a/docs/advanced/mcp_service.zh.md
+++ b/docs/advanced/mcp_service.zh.md
@@ -13,9 +13,9 @@ pip install nexusx[fastmcp]
 最简模式——传入 SQLModel 基类即可：
 
 ```python
-from nexusx.mcp import config_simple_mcp_server
+from nexusx.mcp import create_simple_mcp_server
 
-mcp = config_simple_mcp_server(
+mcp = create_simple_mcp_server(
     base=SQLModel,
     name="My API",
 )
@@ -61,7 +61,7 @@ mcp.run()
 MCP 服务需要 `session_factory` 来执行数据库查询：
 
 ```python
-mcp = config_simple_mcp_server(
+mcp = create_simple_mcp_server(
     base=SQLModel,
     name="My API",
     session_factory=async_session,

--- a/docs/api/api_mcp.md
+++ b/docs/api/api_mcp.md
@@ -2,14 +2,14 @@
 
 Complete API reference for MCP service configuration.
 
-## config_simple_mcp_server
+## create_simple_mcp_server
 
 Create a single-app MCP service.
 
 ```python
-from nexusx.mcp import config_simple_mcp_server
+from nexusx.mcp import create_simple_mcp_server
 
-mcp = config_simple_mcp_server(
+mcp = create_simple_mcp_server(
     base=SQLModel,              # SQLModel base class
     name="My API",              # Service name
     session_factory=async_session,  # Session factory

--- a/docs/api/api_mcp.zh.md
+++ b/docs/api/api_mcp.zh.md
@@ -2,14 +2,14 @@
 
 MCP 服务配置的完整 API 参考。
 
-## config_simple_mcp_server
+## create_simple_mcp_server
 
 创建单应用 MCP 服务。
 
 ```python
-from nexusx.mcp import config_simple_mcp_server
+from nexusx.mcp import create_simple_mcp_server
 
-mcp = config_simple_mcp_server(
+mcp = create_simple_mcp_server(
     base=SQLModel,              # SQLModel 基类
     name="My API",              # 服务名称
     session_factory=async_session,  # session 工厂

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ template: home.html
 | Derived fields | `post_*` methods | Auto-execute after nested data is ready |
 | Cross-layer data flow | `ExposeAs`, `SendTo`, `Collector` | Pass context downward or aggregate results upward |
 | Non-ORM relationships | `Relationship(...)` | Same DataLoader infrastructure, supports auto-loading |
-| AI-ready API | `config_simple_mcp_server(base=...)` | Progressive MCP tool exposure |
+| AI-ready API | `create_simple_mcp_server(base=...)` | Progressive MCP tool exposure |
 
 ## Use Cases
 

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -15,7 +15,7 @@ template: home.html
 | 派生字段 | `post_*` 方法 | 在嵌套数据就绪后自动执行 |
 | 跨层传递数据 | `ExposeAs`、`SendTo`、`Collector` | 向下传上下文，或向上聚合结果 |
 | 非 ORM 关系 | `Relationship(...)` | 同一 DataLoader 基础设施，支持自动加载 |
-| AI 就绪 API | `config_simple_mcp_server(base=...)` | 渐进式 MCP 工具暴露 |
+| AI 就绪 API | `create_simple_mcp_server(base=...)` | 渐进式 MCP 工具暴露 |
 
 ## 适用场景
 

--- a/scripts/check-ci.sh
+++ b/scripts/check-ci.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+uv sync --all-extras
+uv run ruff check src/
+uv run pytest tests/ -v

--- a/src/nexusx/mcp/__init__.py
+++ b/src/nexusx/mcp/__init__.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 
 __all__ = [
     "create_mcp_server",
-    "config_simple_mcp_server",
+    "create_simple_mcp_server",
     "AppConfig",
     "MultiAppManager",
     "SingleAppManager",
@@ -52,5 +52,5 @@ __all__ = [
 ]
 
 from nexusx.mcp.managers import AppResources, MultiAppManager, SingleAppManager
-from nexusx.mcp.server import config_simple_mcp_server, create_mcp_server
+from nexusx.mcp.server import create_simple_mcp_server, create_mcp_server
 from nexusx.mcp.types.app_config import AppConfig

--- a/src/nexusx/mcp/__init__.py
+++ b/src/nexusx/mcp/__init__.py
@@ -52,5 +52,5 @@ __all__ = [
 ]
 
 from nexusx.mcp.managers import AppResources, MultiAppManager, SingleAppManager
-from nexusx.mcp.server import create_simple_mcp_server, create_mcp_server
+from nexusx.mcp.server import create_mcp_server, create_simple_mcp_server
 from nexusx.mcp.types.app_config import AppConfig

--- a/src/nexusx/mcp/server.py
+++ b/src/nexusx/mcp/server.py
@@ -118,7 +118,7 @@ def create_mcp_server(
     return mcp
 
 
-def config_simple_mcp_server(
+def create_simple_mcp_server(
     base: type,
     name: str = "nexusx API",
     desc: str | None = None,
@@ -158,7 +158,7 @@ def config_simple_mcp_server(
         ```python
         from sqlmodel import SQLModel
         from nexusx import query
-        from nexusx.mcp import config_simple_mcp_server
+        from nexusx.mcp import create_simple_mcp_server
 
         class BaseEntity(SQLModel):
             pass
@@ -172,7 +172,7 @@ def config_simple_mcp_server(
                 return await fetch_users()
 
         # Create simplified MCP server
-        mcp = config_simple_mcp_server(
+        mcp = create_simple_mcp_server(
             base=BaseEntity,
             name="My Blog API",
             desc="Blog system with users and posts"
@@ -211,3 +211,20 @@ def config_simple_mcp_server(
     register_simple_tools(mcp, manager, allow_mutation=allow_mutation)
 
     return mcp
+
+
+def config_simple_mcp_server(
+    base: type,
+    name: str = "nexusx API",
+    desc: str | None = None,
+    allow_mutation: bool = False,
+    session_factory: Callable | None = None,
+) -> FastMCP:
+    """Backward-compatible alias for `create_simple_mcp_server`."""
+    return create_simple_mcp_server(
+        base=base,
+        name=name,
+        desc=desc,
+        allow_mutation=allow_mutation,
+        session_factory=session_factory,
+    )

--- a/src/nexusx/mcp/server.py
+++ b/src/nexusx/mcp/server.py
@@ -212,19 +212,3 @@ def create_simple_mcp_server(
 
     return mcp
 
-
-def config_simple_mcp_server(
-    base: type,
-    name: str = "nexusx API",
-    desc: str | None = None,
-    allow_mutation: bool = False,
-    session_factory: Callable | None = None,
-) -> FastMCP:
-    """Backward-compatible alias for `create_simple_mcp_server`."""
-    return create_simple_mcp_server(
-        base=base,
-        name=name,
-        desc=desc,
-        allow_mutation=allow_mutation,
-        session_factory=session_factory,
-    )

--- a/tests/mcp/test_simple_mcp.py
+++ b/tests/mcp/test_simple_mcp.py
@@ -8,7 +8,8 @@ import pytest
 from sqlmodel import Field, SQLModel
 
 from nexusx import mutation, query
-from nexusx.mcp import config_simple_mcp_server
+from nexusx.mcp import create_simple_mcp_server
+from nexusx.mcp.server import config_simple_mcp_server
 from nexusx.mcp.managers.single_app_manager import SingleAppManager
 
 
@@ -104,7 +105,7 @@ class TestGetSchema:
 
     def test_get_schema_returns_sdl(self) -> None:
         """Test get_schema returns SDL format."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity)
         tools = _get_tools_dict(mcp)
         get_schema_tool = tools.get("get_schema")
 
@@ -116,7 +117,7 @@ class TestGetSchema:
 
     def test_get_schema_includes_mutations(self) -> None:
         """Test get_schema includes mutations when allow_mutation=True."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity, allow_mutation=True)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity, allow_mutation=True)
         tools = _get_tools_dict(mcp)
         get_schema_tool = tools.get("get_schema")
 
@@ -127,7 +128,7 @@ class TestGetSchema:
 
     def test_get_schema_excludes_mutations_by_default(self) -> None:
         """Test get_schema excludes mutations when allow_mutation=False (default)."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity)
         tools = _get_tools_dict(mcp)
         get_schema_tool = tools.get("get_schema")
 
@@ -144,7 +145,7 @@ class TestGraphQLQuery:
     @pytest.mark.asyncio
     async def test_graphql_query_with_valid_query(self) -> None:
         """Test graphql_query with valid query."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity)
         tools = _get_tools_dict(mcp)
         graphql_query_tool = tools.get("graphql_query")
 
@@ -158,7 +159,7 @@ class TestGraphQLQuery:
     @pytest.mark.asyncio
     async def test_graphql_query_with_invalid_syntax(self) -> None:
         """Test graphql_query with invalid syntax."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity)
         tools = _get_tools_dict(mcp)
         graphql_query_tool = tools.get("graphql_query")
 
@@ -171,7 +172,7 @@ class TestGraphQLQuery:
     @pytest.mark.asyncio
     async def test_graphql_query_with_empty_query(self) -> None:
         """Test graphql_query with empty query."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity)
         tools = _get_tools_dict(mcp)
         graphql_query_tool = tools.get("graphql_query")
 
@@ -183,7 +184,7 @@ class TestGraphQLQuery:
     @pytest.mark.asyncio
     async def test_graphql_query_with_none_query(self) -> None:
         """Test graphql_query with None query."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity)
         tools = _get_tools_dict(mcp)
         graphql_query_tool = tools.get("graphql_query")
 
@@ -195,7 +196,7 @@ class TestGraphQLQuery:
     @pytest.mark.asyncio
     async def test_graphql_query_with_get_by_id(self) -> None:
         """Test graphql_query with get by ID."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity)
         tools = _get_tools_dict(mcp)
         graphql_query_tool = tools.get("graphql_query")
 
@@ -213,7 +214,7 @@ class TestGraphQLMutation:
     @pytest.mark.asyncio
     async def test_graphql_mutation_create(self) -> None:
         """Test graphql_mutation with create mutation."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity, allow_mutation=True)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity, allow_mutation=True)
         tools = _get_tools_dict(mcp)
         graphql_mutation_tool = tools.get("graphql_mutation")
 
@@ -231,7 +232,7 @@ class TestGraphQLMutation:
     @pytest.mark.asyncio
     async def test_graphql_mutation_with_invalid_syntax(self) -> None:
         """Test graphql_mutation with invalid syntax."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity, allow_mutation=True)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity, allow_mutation=True)
         tools = _get_tools_dict(mcp)
         graphql_mutation_tool = tools.get("graphql_mutation")
 
@@ -243,7 +244,7 @@ class TestGraphQLMutation:
     @pytest.mark.asyncio
     async def test_graphql_mutation_with_empty_mutation(self) -> None:
         """Test graphql_mutation with empty mutation."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity, allow_mutation=True)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity, allow_mutation=True)
         tools = _get_tools_dict(mcp)
         graphql_mutation_tool = tools.get("graphql_mutation")
 
@@ -255,7 +256,7 @@ class TestGraphQLMutation:
     @pytest.mark.asyncio
     async def test_graphql_mutation_with_none_mutation(self) -> None:
         """Test graphql_mutation with None mutation."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity, allow_mutation=True)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity, allow_mutation=True)
         tools = _get_tools_dict(mcp)
         graphql_mutation_tool = tools.get("graphql_mutation")
 
@@ -266,18 +267,18 @@ class TestGraphQLMutation:
 
     def test_mutation_tool_not_registered_by_default(self) -> None:
         """Test graphql_mutation is not registered when allow_mutation=False."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity)
         tools = _get_tools_dict(mcp)
 
         assert "graphql_mutation" not in tools
 
 
 class TestConfigSimpleMCPServer:
-    """Test cases for config_simple_mcp_server function."""
+    """Test cases for create_simple_mcp_server function."""
 
     def test_config_simple_mcp_server_creation(self) -> None:
         """Test creating simple MCP server."""
-        mcp = config_simple_mcp_server(
+        mcp = create_simple_mcp_server(
             base=SimpleMCPMockBaseEntity, name="Test API", desc="Test Description"
         )
 
@@ -286,13 +287,13 @@ class TestConfigSimpleMCPServer:
 
     def test_config_simple_mcp_server_with_defaults(self) -> None:
         """Test creating simple MCP server with defaults."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity)
 
         assert mcp.name == "nexusx API"
 
     def test_config_simple_mcp_server_tools_registered(self) -> None:
         """Test that only 2 tools are registered by default (allow_mutation=False)."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity)
         tools = _get_tools_dict(mcp)
 
         # Should only have 2 tools by default
@@ -312,7 +313,7 @@ class TestConfigSimpleMCPServer:
 
     def test_config_simple_mcp_server_tools_with_mutation(self) -> None:
         """Test that 3 tools are registered when allow_mutation=True."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity, allow_mutation=True)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity, allow_mutation=True)
         tools = _get_tools_dict(mcp)
 
         # Should have 3 tools
@@ -323,7 +324,7 @@ class TestConfigSimpleMCPServer:
 
     def test_config_simple_mcp_server_no_app_name_parameter(self) -> None:
         """Test that tools do not require app_name parameter."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity, allow_mutation=True)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity, allow_mutation=True)
         tools = _get_tools_dict(mcp)
 
         # Check graphql_query tool signature
@@ -349,7 +350,7 @@ class TestSimpleMCPIntegration:
     @pytest.mark.asyncio
     async def test_full_workflow(self) -> None:
         """Test full workflow: get schema -> query -> mutation."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity, allow_mutation=True)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity, allow_mutation=True)
         tools = _get_tools_dict(mcp)
 
         # Step 1: Get schema
@@ -385,7 +386,7 @@ class TestSimpleMCPIntegration:
     @pytest.mark.asyncio
     async def test_read_only_workflow(self) -> None:
         """Test read-only workflow: get schema -> query (no mutations)."""
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity)
+        mcp = create_simple_mcp_server(base=SimpleMCPMockBaseEntity)
         tools = _get_tools_dict(mcp)
 
         # Step 1: Get schema - should not include mutations
@@ -407,3 +408,12 @@ class TestSimpleMCPIntegration:
 
         # Step 3: Mutation tool should not be available
         assert "graphql_mutation" not in tools
+
+
+class TestSimpleMCPServerBackwardCompatibility:
+    """Backward compatibility coverage for deprecated alias."""
+
+    def test_config_simple_mcp_server_alias_still_works(self) -> None:
+        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity)
+
+        assert mcp.name == "nexusx API"

--- a/tests/mcp/test_simple_mcp.py
+++ b/tests/mcp/test_simple_mcp.py
@@ -9,7 +9,6 @@ from sqlmodel import Field, SQLModel
 
 from nexusx import mutation, query
 from nexusx.mcp import create_simple_mcp_server
-from nexusx.mcp.server import config_simple_mcp_server
 from nexusx.mcp.managers.single_app_manager import SingleAppManager
 
 
@@ -409,11 +408,3 @@ class TestSimpleMCPIntegration:
         # Step 3: Mutation tool should not be available
         assert "graphql_mutation" not in tools
 
-
-class TestSimpleMCPServerBackwardCompatibility:
-    """Backward compatibility coverage for deprecated alias."""
-
-    def test_config_simple_mcp_server_alias_still_works(self) -> None:
-        mcp = config_simple_mcp_server(base=SimpleMCPMockBaseEntity)
-
-        assert mcp.name == "nexusx API"


### PR DESCRIPTION
## Summary
- rename the single-app MCP factory to `create_simple_mcp_server`
- keep `config_simple_mcp_server` as a backward-compatible alias
- update docs, demo, and tests to use the canonical API name

## Testing
- `uv run pytest tests/mcp/test_simple_mcp.py -v`

Closes #22