### PR TITLE
MCP Core: remove private GraphQLHandler coupling

### DIFF
--- a/src/nexusx/handler.py
+++ b/src/nexusx/handler.py
@@ -124,6 +124,14 @@ class GraphQLHandler:
             loader_registry=self._er_manager,
         )
 
+    def get_sdl_generator(self) -> SDLGenerator:
+        """Get the public SDL generator used by this handler."""
+        return self._sdl_generator
+
+    def get_introspection_data(self) -> dict[str, Any]:
+        """Get GraphQL introspection data for the current schema."""
+        return self._introspection_generator.generate()
+
     def get_graphiql_html(self, endpoint: str = "/graphql") -> str:
         """Get the GraphiQL HTML template.
 

--- a/src/nexusx/mcp/managers/multi_app_manager.py
+++ b/src/nexusx/mcp/managers/multi_app_manager.py
@@ -62,7 +62,7 @@ class MultiAppManager:
         )
 
         # Create type tracer for progressive disclosure
-        introspection_data = handler._introspection_generator.generate()
+        introspection_data = handler.get_introspection_data()
         entity_names = {e.__name__ for e in handler.entities}
         tracer = TypeTracer(introspection_data, entity_names)
 
@@ -72,7 +72,7 @@ class MultiAppManager:
             description=config.get("description", ""),
             handler=handler,
             tracer=tracer,
-            sdl_generator=handler._sdl_generator,
+            sdl_generator=handler.get_sdl_generator(),
         )
 
     def get_app(self, name: str) -> AppResources:

--- a/src/nexusx/mcp/managers/single_app_manager.py
+++ b/src/nexusx/mcp/managers/single_app_manager.py
@@ -65,12 +65,12 @@ class SingleAppManager:
         )
 
         # Create type tracer for schema introspection
-        introspection_data = self.handler._introspection_generator.generate()
+        introspection_data = self.handler.get_introspection_data()
         entity_names = {e.__name__ for e in self.handler.entities}
         self.tracer = TypeTracer(introspection_data, entity_names)
 
         # Reference to SDL generator
-        self.sdl_generator = self.handler._sdl_generator
+        self.sdl_generator = self.handler.get_sdl_generator()
 
     @property
     def entity_names(self) -> set[str]:

--- a/tests/mcp/test_simple_mcp.py
+++ b/tests/mcp/test_simple_mcp.py
@@ -86,8 +86,9 @@ class TestSingleAppManager:
 
         assert manager.handler is not None
         # Description is passed to SDLGenerator
-        assert manager.handler._sdl_generator._query_description == "Test API"
-        assert manager.handler._sdl_generator._mutation_description == "Test API"
+        sdl_generator = manager.handler.get_sdl_generator()
+        assert sdl_generator._query_description == "Test API"
+        assert sdl_generator._mutation_description == "Test API"
 
     def test_entity_names_property(self) -> None:
         """Test entity_names property."""


### PR DESCRIPTION
## Summary
- add public `GraphQLHandler` accessors for schema/introspection data used by MCP
- update MCP managers to stop reaching into handler private attributes
- adjust the simple MCP manager test to use the new public contract

## Testing
- `uv run pytest tests/mcp/test_simple_mcp.py tests/mcp/test_multi_app_manager.py -v`
- `uv run ruff check src/nexusx/handler.py src/nexusx/mcp/managers/single_app_manager.py src/nexusx/mcp/managers/multi_app_manager.py tests/mcp/test_simple_mcp.py`
- `uv run pytest tests/mcp/ tests/test_mcp.py -v`

## Note
- `uv run ruff check src/ tests/` currently reports an unrelated existing issue in `tests/test_voyager_er_diagram_custom_scalar.py`, so this PR validates changed files plus the MCP-related suite.

Closes #23