### PR TITLE
MCP Manager: validate app config and explicit routing semantics

### DIFF
--- a/src/nexusx/mcp/managers/multi_app_manager.py
+++ b/src/nexusx/mcp/managers/multi_app_manager.py
@@ -37,12 +37,66 @@ class MultiAppManager:
             manager = MultiAppManager(apps)
             ```
         """
+        validated_apps = self._validate_apps(apps)
         self.apps: dict[str, AppResources] = {}
+        self.aliases: dict[str, str] = {}
 
-        # Initialize each application
-        for app_config in apps:
+        for app_config in validated_apps:
             resources = self._create_app_resources(app_config)
-            self.apps[app_config["name"]] = resources
+            app_name = app_config["name"]
+            self.apps[app_name] = resources
+            for alias in app_config.get("aliases", []):
+                self.aliases[alias] = app_name
+
+    @staticmethod
+    def _validate_apps(apps: list[AppConfig]) -> list[AppConfig]:
+        """Validate app configs and normalize aliases."""
+        if not apps:
+            raise ValueError("At least one app configuration is required")
+
+        seen_names: set[str] = set()
+        seen_aliases: set[str] = set()
+        validated_apps: list[AppConfig] = []
+
+        for index, app_config in enumerate(apps):
+            if "name" not in app_config or not app_config["name"]:
+                raise ValueError(f"App config at index {index} is missing required field 'name'")
+            if "base" not in app_config or app_config["base"] is None:
+                app_label = app_config.get("name", f"index {index}")
+                raise ValueError(
+                    f"App '{app_label}' is missing required field 'base'"
+                )
+
+            app_name = app_config["name"]
+            if app_name in seen_names:
+                raise ValueError(f"Duplicate app name '{app_name}' is not allowed")
+            seen_names.add(app_name)
+
+            aliases = app_config.get("aliases", [])
+            if aliases is None:
+                aliases = []
+            if not isinstance(aliases, list):
+                raise ValueError(f"App '{app_name}' aliases must be a list of strings")
+
+            normalized_aliases: list[str] = []
+            for alias in aliases:
+                if not isinstance(alias, str) or not alias:
+                    raise ValueError(
+                        f"App '{app_name}' aliases must contain only non-empty strings"
+                    )
+                if alias == app_name:
+                    raise ValueError(f"App '{app_name}' alias '{alias}' duplicates its name")
+                if alias in seen_names or alias in seen_aliases:
+                    raise ValueError(f"Alias '{alias}' is already used by another app")
+                seen_aliases.add(alias)
+                normalized_aliases.append(alias)
+
+            validated_app: AppConfig = dict(app_config)
+            validated_app["aliases"] = normalized_aliases
+            validated_apps.append(validated_app)
+
+        return validated_apps
+
 
     def _create_app_resources(self, config: AppConfig) -> AppResources:
         """Create resources for a single application.
@@ -93,23 +147,15 @@ class MultiAppManager:
             queries = app.tracer.list_operation_fields("Query")
             ```
         """
-        # Try exact match first
         if name in self.apps:
             return self.apps[name]
 
-        # Smart fallback: try removing common suffixes
-        # Handle cases like "todos_app" -> "todos", "blog_app" -> "blog"
-        normalized_name = name
-        if normalized_name.endswith("_app"):
-            normalized_name = normalized_name[:-4]  # Remove "_app"
-        elif normalized_name.endswith("-app"):
-            normalized_name = normalized_name[:-4]  # Remove "-app"
+        if name in self.aliases:
+            return self.apps[self.aliases[name]]
 
-        if normalized_name in self.apps:
-            return self.apps[normalized_name]
-
-        # No match found, provide helpful error message
         available = list(self.apps.keys())
+        if self.aliases:
+            available += [f"alias:{alias}" for alias in self.aliases]
         raise ValueError(
             f"App '{name}' not found. Available apps: {available}"
         )

--- a/src/nexusx/mcp/types/app_config.py
+++ b/src/nexusx/mcp/types/app_config.py
@@ -19,6 +19,7 @@ class AppConfig(TypedDict, total=False):
         session_factory: Async session factory for DataLoader relationship loading
         query_description: Description for the Query type in GraphQL schema
         mutation_description: Description for the Mutation type in GraphQL schema
+        aliases: Optional alternate names that can route to this application
     """
 
     name: str
@@ -27,3 +28,4 @@ class AppConfig(TypedDict, total=False):
     session_factory: Callable | None
     query_description: str | None
     mutation_description: str | None
+    aliases: list[str]

--- a/tests/mcp/test_multi_app_manager.py
+++ b/tests/mcp/test_multi_app_manager.py
@@ -248,42 +248,29 @@ class TestMultiAppManager:
         # The descriptions are passed to the introspection generator and SDL generator
         assert app.handler is not None
 
-    def test_get_app_with_underscore_app_suffix(self):
-        """Test that get_app handles '_app' suffix intelligently."""
+    def test_get_app_with_explicit_alias(self):
+        """Test that get_app resolves configured aliases."""
         apps: list[AppConfig] = [
             {
                 "name": "todo",
                 "base": MockBaseEntity1,
                 "description": "Todo application",
+                "aliases": ["todo_app", "todo-app"],
             }
         ]
 
         manager = MultiAppManager(apps)
 
-        # Should find "todo" when given "todo_app"
         app = manager.get_app("todo_app")
         assert app.name == "todo"
         assert app.description == "Todo application"
 
-    def test_get_app_with_dash_app_suffix(self):
-        """Test that get_app handles '-app' suffix intelligently."""
-        apps: list[AppConfig] = [
-            {
-                "name": "blog",
-                "base": MockBaseEntity1,
-                "description": "Blog application",
-            }
-        ]
-
-        manager = MultiAppManager(apps)
-
-        # Should find "blog" when given "blog-app"
-        app = manager.get_app("blog-app")
-        assert app.name == "blog"
-        assert app.description == "Blog application"
+        app = manager.get_app("todo-app")
+        assert app.name == "todo"
+        assert app.description == "Todo application"
 
     def test_get_app_exact_match_priority(self):
-        """Test that exact match takes priority over suffix normalization."""
+        """Test that exact match takes priority over aliases."""
         apps: list[AppConfig] = [
             {
                 "name": "test_app",
@@ -294,18 +281,19 @@ class TestMultiAppManager:
                 "name": "test",
                 "base": MockBaseEntity2,
                 "description": "App without suffix",
+                "aliases": ["test_alias"],
             }
         ]
 
         manager = MultiAppManager(apps)
 
-        # Should return exact match "test_app", not "test"
+        # Should return exact match "test_app", not an alias target
         app = manager.get_app("test_app")
         assert app.name == "test_app"
         assert app.description == "App with _app in name"
 
-    def test_get_app_suffix_normalization_fallback(self):
-        """Test that suffix normalization works as fallback when exact match fails."""
+    def test_get_app_requires_explicit_alias(self):
+        """Test that implicit suffix normalization no longer happens."""
         apps: list[AppConfig] = [
             {
                 "name": "shop",
@@ -316,10 +304,10 @@ class TestMultiAppManager:
 
         manager = MultiAppManager(apps)
 
-        # "shop_app" doesn't exist exactly, so it should try "shop"
-        app = manager.get_app("shop_app")
-        assert app.name == "shop"
-        assert app.description == "Shop application"
+        with pytest.raises(ValueError) as exc_info:
+            manager.get_app("shop_app")
+
+        assert "App 'shop_app' not found" in str(exc_info.value)
 
     def test_get_app_still_raises_error_for_invalid_names(self):
         """Test that get_app still raises ValueError for truly invalid names."""
@@ -340,3 +328,61 @@ class TestMultiAppManager:
         assert "App 'invalid_name' not found" in str(exc_info.value)
         assert "Available apps: ['todo']" in str(exc_info.value)
 
+
+
+    def test_duplicate_app_names_raise_error(self):
+        """Test duplicate app names fail fast."""
+        apps: list[AppConfig] = [
+            {"name": "dup", "base": MockBaseEntity1},
+            {"name": "dup", "base": MockBaseEntity2},
+        ]
+
+        with pytest.raises(ValueError) as exc_info:
+            MultiAppManager(apps)
+
+        assert "Duplicate app name 'dup'" in str(exc_info.value)
+
+    def test_empty_apps_raise_error(self):
+        """Test empty app list is rejected."""
+        with pytest.raises(ValueError) as exc_info:
+            MultiAppManager([])
+
+        assert "At least one app configuration is required" in str(exc_info.value)
+
+    def test_missing_name_raises_error(self):
+        """Test missing app name is rejected."""
+        apps: list[AppConfig] = [{"base": MockBaseEntity1}]
+
+        with pytest.raises(ValueError) as exc_info:
+            MultiAppManager(apps)
+
+        assert "missing required field 'name'" in str(exc_info.value)
+
+    def test_missing_base_raises_error(self):
+        """Test missing app base is rejected."""
+        apps: list[AppConfig] = [{"name": "invalid"}]
+
+        with pytest.raises(ValueError) as exc_info:
+            MultiAppManager(apps)
+
+        assert "missing required field 'base'" in str(exc_info.value)
+
+    def test_duplicate_aliases_raise_error(self):
+        """Test duplicate aliases across apps are rejected."""
+        apps: list[AppConfig] = [
+            {"name": "app1", "base": MockBaseEntity1, "aliases": ["shared"]},
+            {"name": "app2", "base": MockBaseEntity2, "aliases": ["shared"]},
+        ]
+
+        with pytest.raises(ValueError) as exc_info:
+            MultiAppManager(apps)
+
+        assert "Alias 'shared' is already used" in str(exc_info.value)
+
+    def test_aliases_must_be_list_of_strings(self):
+        """Test aliases must be a list of non-empty strings."""
+        with pytest.raises(ValueError):
+            MultiAppManager([{"name": "app", "base": MockBaseEntity1, "aliases": "alias"}])
+
+        with pytest.raises(ValueError):
+            MultiAppManager([{"name": "app", "base": MockBaseEntity1, "aliases": [""]}])


### PR DESCRIPTION
## Summary
- validate multi-app configuration up front instead of accepting malformed input
- reject duplicate app names and conflicting aliases with clear errors
- replace implicit `_app` / `-app` fallback routing with explicit `aliases`
- expand manager tests to cover empty configs, missing required fields, duplicate names, and alias rules

## Testing
- `uv run pytest tests/mcp/test_multi_app_manager.py -v`
- `uv run ruff check src/nexusx/mcp/types/app_config.py src/nexusx/mcp/managers/multi_app_manager.py tests/mcp/test_multi_app_manager.py`
- `uv run pytest tests/mcp/test_multi_app_manager.py tests/mcp/test_multi_app_tools.py -v`

Closes #24