### PR TITLE
CI template guard + PR gating + README restructure

### DIFF
--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -1,0 +1,24 @@
+# Companion to ci.yml. The real CI is path-filtered, so a PR that changes
+# only non-code files (docs, etc.) skips ci.yml entirely — leaving the
+# required "CI All Green" check stuck in "Expected" forever and blocking the
+# PR. This workflow runs on the INVERSE path filter and reports the same
+# "CI All Green" check as passing, so such PRs can merge. On a mixed PR both
+# workflows run; both report green, and a real failure still fails the
+# same-named check, so nothing is masked.
+name: Test
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'src/nexusx/**'
+      - 'tests/**'
+      - 'skill/**'
+      - 'pyproject.toml'
+
+jobs:
+  ci-all-green:
+    name: CI All Green
+    runs-on: ubuntu-latest
+    steps:
+      - name: No code paths changed
+        run: echo "No code paths changed — real CI skipped; reporting green."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,21 @@ jobs:
 
       - name: Import template app against working-copy framework
         run: uv run python -c "import sys; sys.path.insert(0, 'skill/template'); import src.main"
+
+  # Single required-status gate. Branch protection should require this ONE
+  # check ("CI All Green") instead of each job (the matrix makes per-job names
+  # awkward). It aggregates the real jobs and fails if any did not succeed.
+  # A mirror job of the same name lives in ci-skip.yml: when a PR touches no
+  # code paths this workflow is skipped entirely, so the mirror reports the
+  # same check as green and docs-only PRs are never blocked on a check that
+  # path filtering skipped.
+  ci-all-green:
+    name: CI All Green
+    if: always()
+    needs: [test, template-guard]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs succeeded
+        run: |
+          echo "test=${{ needs.test.result }} template-guard=${{ needs.template-guard.result }}"
+          [ "${{ needs.test.result }}" = "success" ] && [ "${{ needs.template-guard.result }}" = "success" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,18 @@
 name: Test
 
 on:
-  push:
+  pull_request:
     paths:
       - 'src/nexusx/**'
       - 'tests/**'
+      - 'skill/**'
+      - 'pyproject.toml'
+  push:
+    branches: [master]
+    paths:
+      - 'src/nexusx/**'
+      - 'tests/**'
+      - 'skill/**'
       - 'pyproject.toml'
 
 jobs:
@@ -35,3 +43,33 @@ jobs:
 
       - name: Test with pytest
         run: uv run pytest tests/ -v
+
+  # Guards the skill's reference template against framework API drift.
+  # The template is the skill's first real consumer; if a framework API is
+  # renamed/removed, this job fails on the PR instead of silently shipping a
+  # broken skill that users discover only after generating a project.
+  # Critical: uv sync installs the WORKING-COPY framework (editable), so the
+  # template is verified against the code in this PR — not the PyPI release.
+  template-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install working-copy framework + extras
+        run: uv sync --all-extras
+
+      - name: Compile all template sources
+        run: uv run python -m compileall -q skill/template/src
+
+      - name: Import template app against working-copy framework
+        run: uv run python -c "import sys; sys.path.insert(0, 'skill/template'); import src.main"

--- a/README.md
+++ b/README.md
@@ -18,58 +18,16 @@ flowchart LR
     model --> ai["AI-friendly Layer<br/>MCP tools<br/>Agent integration"]
 ```
 
-## Quick Start with AI Agent Skills
+## Two ways to build with nexusx
 
-This project ships a [skill](./skill/) that operationalizes the same path described above: clarify the idea, build the POC, harden the product surface, then expose it cleanly for AI. The skill uses the standard `SKILL.md` format supported by both Claude Code and OpenAI Codex.
+- **Manually** — use the API directly (GraphQL / Core API / MCP). Start at [Install](#install) and read straight down.
+- **AI-guided** — let an AI coding agent run a structured 4-phase workflow (idea → POC → product → TS SDK). Jump to [AI Bootstrap](#ai-bootstrap).
 
-### Claude Code
-
-```bash
-ln -s $(pwd)/skill ~/.claude/skills/nexusx-4phase
-```
-
-Then describe your requirements and invoke `/nexusx-4phase` to start.
-
-### OpenAI Codex
-
-**Repo-scope** (recommended — skill travels with the repo, all team members get it):
-
-```bash
-mkdir -p .agents/skills
-ln -s ../../skill .agents/skills/nexusx-4phase
-```
-
-**User-scope** (personal, works across all repos):
-
-```bash
-mkdir -p ~/.agents/skills
-ln -s $(pwd)/skill ~/.agents/skills/nexusx-4phase
-```
-
-Then start Codex and type `$nexusx-4phase` or describe your requirements to trigger the skill implicitly.
-
-| Phase | Focus | Output |
-|-------|-------|--------|
-| Phase 0 | Clarify the idea | Entities, relationships, aggregates, use-case methods |
-| Phase 1 | Build the POC model | models + db + voyager |
-| Phase 2 | Make the model queryable | service methods, GraphQL queryable |
-| Phase 3 | Productize and make it AI-ready | DTOs + services + REST + MCP |
-
-Manual setup is also straightforward — see [Install](#install) below.
+If you're evaluating the library, read top to bottom. If you want the agent workflow, skip ahead to the skill.
 
 ## From Idea to Product
 
-The core loop is simple: use one model to move through each delivery stage without rewriting your API surface.
-
-```
-Idea ──> SQLModel entities and relationships
-         ├── GraphQL for fast validation
-         ├── REST + OpenAPI for product delivery
-         ├── MCP for AI agents
-         └── Voyager for visualizing the system
-```
-
-**GraphQL for validation, REST for delivery, MCP for AI.**
+One model moves through each delivery stage without rewriting your API surface — **GraphQL for validation, REST for delivery, MCP for AI.**
 
 At the idea stage, you want feedback quickly: are the entities right, are the relationships right, does the shape of the response support the use case? GraphQL gives you that shortest path. Once the POC proves the model, `DefineSubset` DTOs and route generation turn the same entities into N+1-safe FastAPI endpoints with OpenAPI output, so frontend delivery stops depending on hand-written DTO duplication. When the product also needs to serve AI, the same model and service definitions can be exposed through MCP with progressive disclosure, from schema discovery to method execution.
 
@@ -641,9 +599,43 @@ uv run uvicorn demo.use_case.fastapi:app --port 8007
 # visit /docs to see routes grouped by service tag
 ```
 
-## Skill (Claude Code)
+## AI Bootstrap
 
-See [Quick Start with Claude Code Skill](#quick-start-with-claude-code-skill) at the top of this README for setup instructions and the four-phase workflow.
+> The fastest way to build with nexusx is to let an AI coding agent drive a
+> guided workflow that carries one model across its **whole lifecycle** —
+> idea → POC → product → TS SDK — not just initial scaffolding.
+
+This repo ships a [skill](./skill/) in the standard `SKILL.md` format,
+supported by both Claude Code and OpenAI Codex.
+
+**For the agent** — install the skill, then invoke it:
+
+```bash
+# Claude Code
+ln -s $(pwd)/skill ~/.claude/skills/nexusx-4phase
+# then describe your requirements and run: /nexusx-4phase
+
+# OpenAI Codex (repo-scope — travels with the repo)
+mkdir -p .agents/skills && ln -s ../../skill .agents/skills/nexusx-4phase
+# then start Codex and type: $nexusx-4phase
+
+# OpenAI Codex (user-scope — personal, all repos)
+mkdir -p ~/.agents/skills && ln -s $(pwd)/skill ~/.agents/skills/nexusx-4phase
+```
+
+| Phase | Focus | Output |
+|-------|-------|--------|
+| 0 | Clarify the idea | entities, relationships, aggregates, use-case methods |
+| 1 | Build the POC model | models + db + voyager |
+| 2 | Make the model queryable | service methods, GraphQL queryable |
+| 3 | Productize and make it AI-ready | DTOs + services + REST + MCP |
+| 4 | Generate the SDK | OpenAPI spec → end-to-end TS SDK |
+
+Each phase uses V-shaped acceptance (define criteria, implement, verify) and
+pauses for your confirmation before the next. Full methodology — Phase 0
+checklist, acceptance model, spec rules — lives in
+[`skill/SKILL.md`](./skill/SKILL.md). Whole-API context for agents:
+[`llms-full.txt`](./llms-full.txt).
 
 ## License
 

--- a/scripts/check-ci.sh
+++ b/scripts/check-ci.sh
@@ -4,3 +4,8 @@ set -euo pipefail
 uv sync --all-extras
 uv run ruff check src/
 uv run pytest tests/ -v
+
+# Template guard: verify the skill's reference template still imports against
+# the working-copy framework (catches API drift between framework and skill).
+uv run python -m compileall -q skill/template/src
+uv run python -c "import sys; sys.path.insert(0, 'skill/template'); import src.main"

--- a/skill/template/pyproject.toml
+++ b/skill/template/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "uvicorn",
     "sqlmodel",
     "aiosqlite",
-    "fastmcp>=3.2.4",
+    "fastmcp>=3.1,<3.2",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "nexusx"
-version = "2.4.1"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiodataloader" },


### PR DESCRIPTION
## What

Three related changes that keep the framework and its AI skill in sync, plus a README narrative cleanup.

### 1. Skill template guard (CI)
- New `template-guard` job compiles + imports `skill/template` against the **working-copy** framework (`uv sync` editable install), so a renamed/removed public API fails the PR instead of silently shipping a broken skill that users only discover after generating a project.
- Same two checks added to `scripts/check-ci.sh` for pre-push parity.
- Fix `skill/template` fastmcp pin (`>=3.2.4` → `>=3.1,<3.2`) which conflicted with the framework's own constraint.

### 2. CI triggering + required gate
- Trigger on `pull_request` + push-to-`master` (was: push to any branch), so PRs are gated without same-repo branches double-running.
- Add `skill/**` to the path filter.
- Add a single `CI All Green` gate job + a `ci-skip.yml` mirror so docs-only PRs don't get stuck on a path-filtered required check.

### 3. README restructure
- Lead with the framework (API reference front-loaded); fold all agent-facing content into one `AI Bootstrap` section at the end, linking to `skill/SKILL.md` + `llms-full.txt`.
- Sharpens the build-time-AI (skill) vs run-time-AI (MCP) distinction.

## Notes
- To enable the gate: Settings → Branches → require **`CI All Green`** only (not the individual matrix jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
