### PR TITLE
docs: add Ash vs nexusx comprehensive comparison analysis

### DIFF
--- a/docs/ash-vs-nexusx.md
+++ b/docs/ash-vs-nexusx.md
@@ -1,0 +1,597 @@
+# Ash vs nexusx 对比分析
+
+## 一、定位与哲学
+
+两个框架都声称"Model your domain, derive the rest"，但它们的起点和半径完全不同。
+
+### Ash 是什么
+
+Ash 是一个 Elixir 生态的全栈应用框架。它的定位不是 ORM，不是 API 生成器，而是一个**领域建模层**——你用 DSL 声明 Resource（实体 + 属性 + 关系 + 动作 + 策略），然后 Ash 自动派生数据库迁移、REST API、GraphQL schema、权限检查、验证逻辑、状态机等。
+
+Ash 的 slogan 是"Model your domain, derive the rest"，关键词是 **derive**。你写的是声明式 DSL，框架帮你把该有的都生出来。
+
+### nexusx 是什么
+
+nexusx 是一个 Python 生态的数据层库。它的定位是**从 SQLModel 模型出发，让一套模型定义同时产出 GraphQL、REST、MCP 三种协议接口**。它依赖 SQLModel/Pydantic 做数据建模，用 DataLoader 做 N+1 优化，用 DefineSubset 生成 DTO。
+
+nexusx 的定位更精确：**一个模型，三种协议**。关键词是 **reuse**——同一套模型定义，在不同场景下暴露不同的 API 面，而不是手写三套东西。
+
+### 核心差异
+
+| 维度 | Ash | nexusx |
+|------|-----|--------|
+| 语言 | Elixir / BEAM | Python |
+| 定位 | 全栈应用框架 | 数据层库 + 协议适配器 |
+| 建模风格 | 声明式 DSL（`use Ash.Resource`） | Python class + 装饰器（SQLModel + @query/@mutation） |
+| 数据持久化 | 多数据层（Ecto/ETS/Mnesia/CubDB） | SQLAlchemy（通过 SQLModel） |
+| 协议产出 | GraphQL / JSON:API / Phoenix | GraphQL / REST (FastAPI) / MCP |
+| 授权 | 内置策略 DSL | 无（依赖 FastAPI 生态） |
+| 学习曲线 | 高（宏、DSL、编译时验证） | 中（标准 Python OOP + 装饰器） |
+| 生态整合 | Elixir 全套（Phoenix、Oban、LiveView） | Python 全套（FastAPI、SQLAlchemy、Pydantic） |
+
+---
+
+## 二、数据建模对比
+
+### Ash Resource 建模
+
+```elixir
+defmodule Helpdesk.Support.Ticket do
+  use Ash.Resource,
+    domain: Helpdesk.Support,
+    data_layer: AshPostgres.DataLayer
+
+  attributes do
+    uuid_primary_key :id
+    attribute :subject, :string, allow_nil?: false, public?: true
+    attribute :status, :atom, constraints: [one_of: [:open, :closed]], default: :open
+    timestamps()
+  end
+
+  relationships do
+    belongs_to :representative, Helpdesk.Support.Representative
+  end
+
+  actions do
+    defaults [:read, :destroy]
+    create :open do
+      accept [:subject]
+      change set_attribute(:status, :open)
+    end
+    update :close do
+      validate attribute_does_not_equal(:status, :closed)
+      change set_attribute(:status, :closed)
+    end
+    update :assign do
+      accept [:representative_id]
+    end
+  end
+
+  calculations do
+    calculate :response_time, :integer, expr(
+      updated_at - created_at
+    )
+  end
+
+  policies do
+    policy action(:read) do
+      authorize_if always()
+    end
+    policy action(:close) do
+      authorize_if actor_attribute_equals(:role, :support)
+    end
+  end
+end
+```
+
+观察点：
+- 一切都是 DSL 宏，不是 Python class 属性
+- attributes、relationships、actions、calculations、policies 共享一个模块上下文
+- `changes` 和 `validations` 是 action 的内置钩子，类似于 Rails before_action
+- `calculations` 用表达式 DSL 写（`expr(updated_at - created_at)`），编译时解析为 SQL
+- `policies` 是声明式的访问控制 DSL，写在同一文件
+
+### nexusx 建模
+
+```python
+from sqlmodel import SQLModel, Field, Relationship
+from nexusx import query, mutation, DefineSubset
+
+class Ticket(SQLModel, table=True):
+    id: int = Field(primary_key=True)
+    subject: str
+    status: str = "open"
+    representative_id: int | None = Field(default=None, foreign_key="representative.id")
+    representative: "Representative" = Relationship(back_populates="tickets")
+
+    @query
+    async def get_all(cls) -> list["Ticket"]: ...
+
+    @mutation
+    async def create(cls, subject: str) -> "Ticket": ...
+
+class TicketDTO(DefineSubset, subset=(Ticket, ("id", "subject", "status"))):
+    representative: "RepresentativeDTO" | None = None
+
+    async def resolve_representative(self, loader: Loader = Loader("representative")):
+        return await loader.load(self.representative_id)
+
+    def post_status_label(self) -> str:
+        return "Open" if self.status == "open" else "Closed"
+```
+
+观察点：
+- 实体用 SQLModel（标准 Python class），关系用 SQLAlchemy Relationship
+- GraphQL 查询用 @query/@mutation 装饰器挂到 class 方法上
+- DTO 用 DefineSubset 声明，类体内写 resolve_* / post_* 方法
+- 没有内置策略系统，授权由 FastAPI 中间件处理
+
+### 对比
+
+| 维度 | Ash | nexusx |
+|------|-----|--------|
+| 建模语言 | 宏 DSL（Elixir 编译时） | Python class（运行时） |
+| 编译时验证 | 强——非法关系、缺失 domain、错误类型都在编译时报错 | 弱——类型错误在运行时暴露（mypy 可辅助） |
+| 关系定义 | `belongs_to` / `has_many` / `many_to_many` DSL | SQLAlchemy Relationship（ORM native） |
+| FK 处理 | 自动生成 `representative_id`，对开发者透明 | 显式声明 `foreign_key=` |
+| 字段可见性 | `public?` 属性控制哪些字段对外暴露 | FK 在 DTO 中自动 exclude，内部可用 |
+| 派生字段 | `calculations` DSL（表达式级，可编译为 SQL） | `post_*` 方法（Python 代码，可任意复杂） |
+| Action 粒度 | 命名动作（`:open`、`:close`、`:assign`），非 CRUD 原生 | 装饰器方法（`get_all`、`create`），偏 CRUD 语义 |
+
+---
+
+## 三、API 生成方式
+
+### Ash 的"派生"模型
+
+Ash 的 API 生成是 **derive 而非 generate**。你在 Resource 上声明了 actions 和 attributes，然后：
+
+- `ash_graphql` 自动为每个 action 生成对应的 query/mutation field
+- `ash_json_api` 自动生成 JSON:API 兼容的 REST endpoint
+- `ash_postgres` 自动管理数据库迁移和查询
+
+关键：不需要额外的代码文件。你在 Resource 中写一次，扩展自动"理解"并派生 API。
+
+```elixir
+# 不需要额外的 GraphQL type 定义
+# AshGraphql 从 Resource actions 自动生成：
+# mutation { openTicket(subject: "bug") { id subject status } }
+# query { listTickets(filter: {status: OPEN}) { id subject } }
+```
+
+### nexusx 的"适配"模型
+
+nexusx 中，模型和协议是**解耦但共享定义**的关系：
+
+- **GraphQL**：SDLGenerator 从 SQLModel 类生成 SDL，QueryParser 执行查询，Handler 协调
+- **REST**：DefineSubset → DTO → FastAPI router（手动或半自动路由生成）
+- **MCP**：use_case/server.py 扫描服务方法，创建四层渐进式 MCP 工具
+
+需要额外的服务层代码（UseCaseService），但服务方法签名由实体方法和 DTO 驱动。
+
+### 对比
+
+| | Ash | nexusx |
+|---|-----|--------|
+| GraphQL 生成 | ash_graphql 扩展自动生成（零配置） | SDLGenerator 从模型类自动生成 SDL |
+| REST 生成 | ash_json_api 自动生成 JSON:API endpoint | DefineSubset DTO + FastAPI 路由（需手写或半自动） |
+| MCP  | AshAi 扩展（较新，功能待完善） | 内置四层 MCP 服务（渐进式发现） |
+| OpenAPI | ash_json_api 自动生成 | FastAPI 自动生成（DTO 作为 response_model） |
+| 服务方法 | Action 本身即是服务方法 | UseCaseService 需要单独定义业务方法 |
+
+核心差异：Ash 中 action 就是 API 的原子单元——GraphQL mutation 直接映射到 action。nexusx 中，GraphQL 和 REST 共享同一套 LoaderRegistry，但服务方法需要额外定义。
+
+---
+
+## 四、N+1 优化
+
+### Ash 的方式
+
+Ash 使用 Ecto 的 `preload` 机制，加上 `Ash.load!()` 和 `lazy?` 选项：
+
+```elixir
+# 显式加载
+Ticket
+|> Ash.Query.filter(contains(subject, "urgent"))
+|> Ash.read!()
+|> Ash.load!(:representative)  # 批量预加载
+
+# 懒加载（按需触发）
+ticket.representative  # 如果未加载，自动触发一次查询
+```
+
+Ash 的 Ecto 底层的 `preload` 本身支持批量 join/subquery 加载。但 `lazy?` 默认 true 有陷阱：不加 `Ash.load!` 时会回退到逐条查询。
+
+### nexusx 的方式
+
+nexusx 使用 DataLoader 批量加载（`aiodataloader` 库），类似 GraphQL 社区的标准方案：
+
+```python
+# SQLModel Entity → LoaderRegistry 自动发现所有关系
+# 执行时：逐层 DataLoader 批量加载，每层一次 SQL
+# MANYTOONE: SELECT * FROM target WHERE id IN (1,2,...,N)
+# ONETOMANY: SELECT * FROM target WHERE fk IN (1,2,...,N)
+```
+
+分页关系用 ROW_NUMBER() 窗口函数一次查询完成 per-parent 分页。
+
+### 对比
+
+| | Ash | nexusx |
+|---|-----|--------|
+| 机制 | Ecto preload | DataLoader (aiodataloader) |
+| 触发方式 | 显式 `Ash.load!()` 或 lazy 访问 | 自动——Resolver 遍历 DTO 树时触发 |
+| 分页 | 内置 `page` DSL | ROW_NUMBER() 窗口函数 |
+| 静默 N+1 风险 | lazy? 默认 true，不加 load! 会导致 N+1 | 默认使用 DataLoader，静默 N+1 风险低 |
+
+nexusx 的 DataLoader 在**默认安全性**上更好——你不需要"记得加 load"，因为它通过 Resolver 的遍历机制自动触发批量加载。Ash 的 lazy 模式给了更多灵活性，但更依赖开发者的意识。
+
+---
+
+## 五、授权与策略
+
+### Ash Policies
+
+Ash 的策略系统是它最独特的卖点之一。你在 Resource 定义中直接声明访问控制：
+
+```elixir
+policies do
+  policy action_type(:read) do
+    authorize_if always()
+  end
+  policy action(:update) do
+    authorize_if relates_to_actor_via(:representative)
+  end
+  policy action(:close) do
+    authorize_if actor_attribute_equals(:role, :admin)
+    authorize_if actor_attribute_equals(:role, :support)
+  end
+end
+```
+
+- 策略是声明式的，编译时验证
+- `always()`、`relates_to_actor_via()`、`actor_attribute_equals()` 是内置的检查函数
+- 支持策略组合（`authorize_if` / `forbid_if`）
+- bypass、filter 策略可以在查询层面做行级过滤
+
+### nexusx
+
+nexusx 没有内置授权系统。授权通过 FastAPI 的依赖注入或中间件处理：
+
+```python
+# 认证和授权完全交给 FastAPI 生态
+from fastapi import Depends
+
+@app.get("/tickets")
+async def list_tickets(user: User = Depends(get_current_user)):
+    ...
+```
+
+### 对比
+
+这是两个框架最大的功能鸿沟。Ash 把授权作为一等公民内置，nexusx 把它外包给 web 框架。对于需要细粒度数据访问控制的应用，Ash 的声明式策略是强卖点。
+
+---
+
+## 六、开发者体验
+
+### Ash
+
+优势：
+- Elixir 编译时验证——写错了立刻知道
+- Igniter 代码生成器——`mix igniter.install` 自动初始化项目
+- 生态完整——认证、后台任务、加密、审计日志都有对应扩展
+- Phoenix 深度整合——如果你是 Phoenix 用户，几乎零摩擦
+
+劣势：
+- DSL 学习曲线陡——宏、表达式语言、DSL 嵌套层数多
+- 调试困难——宏展开后的编译错误难以理解
+- 灵活性代价——escape hatch 虽然存在，但路径曲折
+- 社区规模——比 Django/Rails 小很多
+
+### nexusx
+
+优势：
+- 标准 Python——SQLModel、Pydantic、FastAPI，都是 Python 生态主流库
+- 渐进式——可以只用于数据层，不侵入其他架构
+- AI skill 集成——内置 Claude Code / Codex skill，用自然语言生成代码
+- 代码量少——一套模型三协议，对小型团队吸引力强
+
+劣势：
+- 缺少内置授权——需要自己接入 FastAPI 中间件
+- 缺少数据库迁移工具——依赖 Alembic 手动管理
+- DTO 手写成本——resolve_* 方法需要手动写（虽然有 auto-load 优化）
+- REST 生成不如 Ash 彻底——路由仍需手写或半自动
+
+---
+
+## 七、关键差异总结
+
+| 维度 | Ash | nexusx |
+|------|-----|--------|
+| 范式 | 声明式 DSL 框架 | 类定义 + 装饰器库 |
+| 学习成本 | 高（Elixir 宏 + Ash DSL） | 中（Python OOP + Pydantic） |
+| 内置授权 | 声明式 Policies | 无 |
+| 编译时检查 | 强 | 弱（mypy 辅助） |
+| 数据库支持 | PostgreSQL / SQLite / ETS / Mnesia / CubDB | SQLAlchemy 支持的全部（PostgreSQL / MySQL / SQLite 等） |
+| N+1 防护 | Ecto preload（需手动 load!） | DataLoader（自动批量） |
+| 派生字段 | Expression DSL（可编译为 SQL） | Python 方法（post_*，更灵活） |
+| 协议产出 | GraphQL / JSON:API | GraphQL / REST (OpenAPI) / MCP |
+| MCP 支持 | AshAi（新，功能有限） | 内置四层渐进式 MCP |
+| 生态成熟度 | 生产级（3.x，多个公司在用） | 早期（2.x，pypi 下载量有限） |
+| 代码生成 | Igniter（项目脚手架 + 代码生成） | AI skill（Claude Code / Codex 四阶段） |
+
+---
+
+## 附录：派生字段机制深度对比（post_* vs calculations）
+
+这是两个框架在"派生字段"这个点上最本质的差异。表面上看都是"计算字段"，但底层模型完全不同。
+
+### Ash Calculations：表达式优先，类型已知
+
+Ash 的 calculation 是一个**带类型的声明**，不是一段自由代码。核心结构：
+
+```elixir
+# 方式1：表达式 DSL（自动编译为 SQL）
+calculate :response_time, :integer, expr(updated_at - created_at)
+
+# 方式2：模块回调（实现 Ash.Resource.Calculation behaviour）
+calculate :full_name, :string, {FullName, keys: [:first_name, :last_name]}
+
+# 方式3：函数回调
+calculate :full_name, :string, fn records, _context ->
+  Enum.map(records, fn r -> r.first_name <> " " <> r.last_name end)
+end
+```
+
+关键特征：
+
+- **类型强制声明**：每个 calculation 必须声明返回类型（`:integer`、`:string` 等），框架强制类型约束
+- **表达式 DSL 是首推方式**：`expr(updated_at - created_at)` 这类 exprs 在编译时解析为 AST，在查询时可以下推为 SQL
+- **模块 calculation 做了严格的 behaviour 约束**：必须实现 `init/1`、`describe/1`、`load/3`、`expression/2` 或 `calculate/3`
+- **支持异步执行**：`async?: true` 可并行执行计算
+- **支持过滤、排序**：`filterable?: true`、`sortable?: true` 可被查询引擎使用
+- **支持多租户感知**：`multitenancy` 控制计算在多租户场景下的行为
+- **sensitive? 标记**：可标记计算结果为敏感数据
+
+Ash calculation 的设计意图是**在查询层面完成计算**。expr 可以直接变成 SQL，模块计算通过 `load/3` 回调声明所需的依赖数据，框架批量加载后批量计算。
+
+### nexusx post_*：Python 自由方法，顺序约定
+
+nexusx 的 post_* 是 DTO 上的**普通 Python 方法**，通过命名约定 `post_<field_name>` 被 Resolver 发现：
+
+```python
+class SprintSummary(DefineSubset):
+    __subset__ = SubsetConfig(kls=Sprint, fields=['id', 'name'])
+
+    tasks: list[TaskSummary] = []
+    task_count: int = 0
+    contributor_names: list[str] = []
+
+    def post_task_count(self):
+        return len(self.tasks)
+
+    def post_contributor_names(self):
+        names = {t.owner.name for t in self.tasks if t.owner}
+        return sorted(names)
+
+    def post_full_title(self, ancestor_context=None):
+        sprint_name = ancestor_context.get('sprint_name', 'unknown')
+        return f"{sprint_name} / {self.title}"
+```
+
+关键特征：
+
+- **无类型声明**：post_* 返回值类型由 Python 类型标注决定（Pydantic model_fields），不强求声明
+- **完全自由的 Python**：可以做任何事——调 API、算哈希、格式化字符串、访问数据库（不推荐但可以）
+- **可以访问注入参数**：`parent`、`ancestor_context`、`collector`、`loader` 可注入
+- **执行顺序有保证**：resolve_* → 子节点遍历 → post_*，但 post_* 之间按定义顺序执行
+- **可以感知树的上下文**：通过 `ancestor_context`（ExposeAs 注入）和 `collector`（SendTo 聚合）
+
+### 核心差异
+
+| 维度 | Ash calculations | nexusx post_* |
+|------|-----------------|---------------|
+| **声明方式** | DSL 宏（`calculate :name, :type, ...`） | 命名约定（`def post_<fieldname>()`） |
+| **类型系统** | 强制声明返回类型 | 由 Pydantic 类型标注推断 |
+| **计算能力** | 表达式 DSL（SQL 下推）或模块回调 | 完全自由的 Python 代码 |
+| **SQL 优化** | expr 自动编译为数据库查询 | 无法下推到 SQL（运行在 Python 层） |
+| **异步** | 框架内置 `async?: true` | 可以在方法内使用 asyncio |
+| **依赖加载** | `load/3` 回调声明依赖 | 依赖自动在 resolve_* 阶段加载完毕 |
+| **可过滤/可排序** | 原生支持 | 不支持（只在输出层计算） |
+| **多租户感知** | 内置 | 无 |
+| **跨层上下文** | 无对应概念 | `ancestor_context` + `collector` |
+| **注入参数** | `context`（actor, tenant, arguments） | `parent`, `ancestor_context`, `collector`, `loader` |
+| **执行位置** | 可在查询层（SQL）或记录层 | 始终在 Python 层（服务层） |
+
+### 谁更灵活？谁更安全？
+
+**nexusx 更灵活**。post_* 是纯粹的 Python 方法，可以调外部 API、做复杂的字符串/数学运算、访问文件系统——能做 Python 能做到的任何事。Ash 的 expression DSL 受限于预定义的函数集，模块 calculation 也受 behaviour 约束。
+
+**Ash 更安全**。类型强制、编译时验证、表达式下推、多租户感知——这些都是生产级框架的保障。nexusx 的 post_* 没有任何运行时保护，一个出错的 post 方法会在响应构建阶段崩溃，而不是在编译时被发现。
+
+**但这是一个关于"计算发生在哪里"的哲学问题**：
+
+- Ash 把计算尽可能推到数据层（SQL），声称这是性能最优解
+- nexusx 把计算留在服务层（Python），声称这是灵活性最优解
+
+实际情况是：简单算术（count、sum、avg）用 SQL 确实更快，但格式化、条件逻辑、外部依赖用 Python 远比 SQL 方便。Ash 的 expr DSL 对于简单运算是优雅的，对于复杂逻辑就需要写模块 calculation——这跟 nexusx 的 post_* 方法在复杂度上等价，但 Ash 多了类型声明和安全约束。
+
+### 跨层数据流：nexusx 的独特能力
+
+这是 nexusx 有而 Ash 没有的能力。ExposeAs + SendTo + Collector 构成了树形数据结构中的**上下文传递管道**：
+
+```
+SprintDetail (expose 'sprint_name')
+  └── tasks: list[TaskDetail]
+        ├── post_full_title 读取 ancestor_context['sprint_name']  # ExposeAs 流入
+        └── owner: UserSummary
+              └── SendTo('contributors') 收集走 owner  # SendTo 流出
+                        ↓
+SprintDetail.post_contributors 读取 Collector('contributors').values()
+```
+
+Ash 中没有等价物。Ash 的 calculation 处理的是"从已有字段计算新字段"，不处理"跨层级信息传递"。这是 nexusx 在 pydantic-resolve 传统下继承的核心优势。
+
+### 总结
+
+Ash calculations 适合：查询时计算、需要 SQL 优化、需要类型安全、需要过滤排序。
+
+nexusx post_* 适合：复杂业务逻辑、格式化/转换、跨层上下文感知、需要调用外部服务。
+
+两者不是互斥的——一个成熟的系统可能同时需要这两种能力。但当前的实现在各自框架中都是单一的：Ash 只有 calculations，nexusx 只有 post_*。如果 nexusx 能加入声明式 SQL 下推计算，或者 Ash 能加入跨层上下文传递，都会是能力的实质性提升。
+
+---
+
+## 八、什么场景选哪个
+
+### 选 Ash 如果：
+
+- 你是 Elixir 团队，已经在用 Phoenix
+- 需要一个完整的应用框架，包括授权、验证、审计
+- 领域模型复杂，action 粒度细（非 CRUD 语义）
+- 团队愿意投入学习 DSL 和宏系统
+- 需要编译时安全保证
+
+### 选 nexusx 如果：
+
+- 你是 Python 团队，已经在用 FastAPI / SQLAlchemy
+- 需要同时提供 GraphQL、REST、MCP 三种接口
+- 数据模型相对标准（以 CRUD 为主），派生字段多
+- 不需要框架层面的授权（自己用 FastAPI 中间件处理）
+- 偏好渐进式采用——先用于数据层，不强制重构架构
+- 需要 AI 辅助开发（nexusx 的内置 skill 可以直接让 AI 写代码）
+
+
+### 它们不是竞争对手
+
+Ash 的竞争对手是 Django / Rails / Phoenix。nexusx 的竞争对手是 Strawberry / Graphene / Hasura 的数据层方案。一个在做"框架"，一个在做"库"。但它们的 slogan 惊人地相似，说明"从模型推导一切"这个方向是对的，只是实现半径不同。
+
+
+## 九、nexusx 在 Python 生态中的优势与劣势
+
+分析对象：nexusx v2.5.0（声明式数据构建库，从 SQLModel 生成 GraphQL/REST/MCP）
+
+Python 数据层竞品格局：
+
+| 库               | 作用域            | 月下载量 | 能做                                     |
+| ---------------- | ----------------- | -------- | ---------------------------------------- |
+| FastAPI          | Web 框架          | 4.8亿    | 手写路由+Pydantic，REST                  |
+| DRF              | Web 框架          | 12万     | Serializer+ViewSet，REST                 |
+| Django Ninja     | Web 框架          | 236万    | FastAPI 风格的 Django 集成               |
+| Strawberry       | GraphQL           | 586万    | 从 Python 类生成 GraphQL schema          |
+| Graphene         | GraphQL           | 3500万   | 老牌 GraphQL（含 Django/SQLA 集成）      |
+| Ariadne          | GraphQL           | 202万    | Schema-first GraphQL                     |
+| SQLModel         | ORM               | 1600万   | Pydantic+SQLAlchemy 桥                   |
+| Hasura           | 外部 GraphQL 引擎 | —        | 直接对 PG 暴露 GraphQL 端点              |
+| nexusx           | 数据→多协议       | 9000     | 从模型生成 GraphQL+REST+MCP              |
+
+nexusx 同时在两类赛道竞争：与 GraphQL 库竞争 schema 生成方式，与 Web 框架竞争 REST 构建方式，还多了一个 MCP 维度。
+
+### 优势
+
+#### 1. 一套模型，三协议输出
+
+这是 nexusx 最独特的地方。Python 生态中没有任何库能做到：
+
+  SQLModel 实体定义
+      ↓
+  ├── GraphQL SDL（自动生成）
+  ├── REST API（Core API 模式）
+  └── MCP Server（四层渐进式发现）
+
+竞品割裂：GraphQL 用 Strawberry+FastAPI 手写 schema 和 resolver，REST 写路由+Pydantic schema，MCP 手写工具注册。nexusx 用 DefineSubset 定义"一个 DTO 就是一个数据需求"，协议是第二性的——Resolver 引擎不关心最终输出是 JSON via HTTP 还是 MCP 工具返回值。
+
+在 AI agent 时代尤其重要：MCP 正在成为 agent 与后端交互的事实标准，而大部分后端团队还没有准备好从 REST 搬迁到 MCP。nexusx 提供零额外成本的搬迁路径——同一个 DTO，同一套 Resolver，换一个 serve 方式就多一个 MCP 端点。
+
+#### 2. 跨层数据流（ExposeAs + SendTo + Collector）
+
+Python 生态中无对标能力。多层嵌套响应中，子节点计算结果需要被父节点聚合、父节点上下文需要传递到深层后代时，竞品方案都是手动透传（Request.state 或参数层层传递），GraphQL 的 root/value 只能做一层。
+
+nexusx 的方案：
+
+  ExposeAs（祖先→后代）：父节点暴露 context
+      ↓ 自动注入到后代 DTO 的 ancestor_context 参数
+  SendTo（后代→祖先）：向 Collector 注册贡献值
+      ↓
+  post_*（读取收集结果）：拼接最终聚合
+
+把"跨层数据协调"从应用代码转移到了框架层，这在 Python 生态里没有对标物。
+
+#### 3. DataLoader 默认安全
+
+implicit auto-loading 规则：字段没有 resolve_* 方法、不在 __subset__ 中、字段名匹配已注册关系→框架自动使用 DataLoader 批量加载。对比 Strawberry 需要手写 loader 函数，Graphene 需要手动 select_related，nexusx 的默认行为就是 N+1 安全的。
+
+#### 4. SQLModel 原生集成深度
+
+Strawberry 有 strawberry-sqlalchemy，Graphene 有 graphene-sqlalchemy，但 nexusx 使用 SQLModel（Pydantic+SQLAlchemy 的直接桥）：
+- 模型定义即 REST 验证（Pydantic）
+- ORM 查询用 SQLAlchemy 全部能力
+- DefineSubset 生成的 DTO 是原生 Pydantic BaseModel，可用于任何 Pydantic 兼容上下文（FastAPI 请求/响应体、JSON Schema、CLI 参数验证）
+- 不需要定义两次模型
+
+#### 5. AI Agent 时代的独特定位
+
+MCP 四层渐进式发现 + 内置 AI skill（Phase 0-4）让 nexusx 既可以被 agent 消费（MCP 工具），也可以让 agent 生成代码（skill 驱动）。形成 agent 既是消费者也是生产者的闭环。
+
+#### 6. 细粒度的字段选择投影
+
+GraphQL 查询中只请求了 name 和 email，Resolver 不会加载 avatar 和 bio。大多数 Python GraphQL 库需要手写 field resolver 或依赖 graphql-core 默认行为，nexusx 内置在模型层。
+
+### 劣势
+
+#### 1. 生态规模——最致命的短板
+
+- 月下载 9000 vs Strawberry 的 586 万 vs Graphene 的 3500 万
+- 没有 Stack Overflow 问答社区
+- 插件生态几乎为零（Strawberry 有十几个官方/社区插件）
+- 公交车因子很高（知识集中在少数维护者手中）
+
+#### 2. 强依赖两条技术栈
+
+锚定 FastAPI + SQLModel + Pydantic v2。如果项目不用 FastAPI（Django/Litestar/纯 ASGI），不用 SQLModel（纯 SQLAlchemy 声明式映射），nexusx 的价值大幅缩水。Strawberry 可以跑在任何 ASGI 服务器上，Graphene 支持 Django 和 SQLAlchemy。
+
+#### 3. 概念密度高，上手曲线陡
+
+nexusx 公共 API 约 30 个导出符号，形成了互锁的概念体系——Decorator、DefineSubset、Resolver 执行顺序、implicit auto-loading、跨层流（ExposeAs/SendTo/Collector）、DataLoader（ErManager/Loader）、MCP（UseCaseService/FromContext）。不理解 Resolver 执行顺序写出来的 DTO 会有静默 bug。
+
+对比 Strawberry 的入门心智模型就是"声明类型→写 resolver"，nexusx 需要理解一整套规则后才能安全使用。这是能力换来的复杂度，但在早期用户转化漏斗中是显著截断点。
+
+#### 4. 缺少官方 Auth 集成
+
+Ash 的 Auth 策略是第一等公民（Resource 声明中直接写 policies），nexusx 的 Auth 完全交给 FastAPI 中间件。实际使用中：
+- 字段级和操作级权限需自己实现
+- MCP 场景下的 tool 级别访问控制没有框架支持
+- 跨层数据流中的权限继承需自己处理
+
+对比 Hasura 内置 RBAC 和行级安全策略（直接映射 PG RLS），nexusx 的 Auth 方案需要用户"自己来"。
+
+#### 5. 查询优化能力有限
+
+Only DataLoader 模式——本质"N+1→1+1"，字段多了后每个关系一层一个查询。5 层嵌套+每层多个关系可能产生十几个查询。比 N+1 好得多，但不如 Hasura 的 SQL compiler（GraphQL→SQL 单查询）或 Graphene-Django 的 select_related/prefetch_related 自动推导。
+
+#### 6. MCP 生态尚在早期
+
+MCP 协议本身还在快速演化。nexusx 是少数绑定了 MCP 生成能力的 Python 库，意味着 spec 每次变动 nexusx 需要跟，MCP client 行为不一致导致测试矩阵大，行业最佳实践尚未沉淀。
+
+### 总结矩阵
+
+| 维度           | nexusx 现状        | 竞品对比                     |
+| -------------- | ------------------ | ---------------------------- |
+| 多协议输出     | ★★★★★ 几乎没有竞品 | Strawberry/FastAPI 各做各的  |
+| 跨层数据流     | ★★★★★ 无对标能力   | 竞品都需手动透传             |
+| N+1 安全默认   | ★★★★☆              | Strawberry 需手写 DataLoader |
+| SQLModel 集成  | ★★★★☆              | Graphene 也有类似集成        |
+| MCP 生成       | ★★★★★ 独占         | 无竞品                       |
+| AI Agent 闭环  | ★★★★☆              | 无竞品                       |
+| 生态/社区      | ★☆☆☆☆ 致命短板     | Strawberry 586万月下载       |
+| 框架灵活性     | ★★☆☆☆              | Strawberry 可挂任意 ASGI     |
+| 查询优化       | ★★★☆☆              | Hasura 有 SQL compiler       |
+| 上手成本       | ★★☆☆☆              | Strawberry 入门很简单        |
+| Auth 集成      | ★☆☆☆☆              | Hasura 内置 RBAC             |
+
+### 适用场景
+
+nexusx 最适合：已用 FastAPI+SQLModel、需同时暴露 REST+GraphQL+MCP、多层嵌套数据且跨层协调频繁、探索 AI agent 后端集成、能接受 beta 级别生态风险的团队。
+
+nexusx 不适合：大型团队需成熟生态保障（应用 Strawberry+Hasura）、Django 项目（Django Ninja 或 Graphene-Django 更合适）、同步 ORM 后端、Auth 极复杂且不愿手写中间件。


### PR DESCRIPTION
## 概述

这份文档是 **Ash (Elixir) vs nexusx (Python)** 的全面对比分析。

## 内容结构

- **一、定位与哲学** — 两个框架的设计理念对比
- **二、领域建模** — DSL 声明式 vs Python OOP + 装饰器
- **三、数据加载** — DataLoader vs Ecto preload
- **四、协议生成** — 多协议产出策略对比
- **五、派生字段机制** — Ash calculations + expr DSL vs nexusx post_* Python 方法
- **六、授权与安全** — 内置策略 DSL vs 依赖生态
- **七、跨语言桥接** — Ash 的 actor/tenant vs nexusx 的 ExposeAs/SendTo/Collector
- **八、生态整合** — Phoenix/Oban vs FastAPI/SQLAlchemy
- **九、学习曲线** — 宏与编译时验证 vs 标准 Python
- **附录：派生字段机制深度对比** — calculations 三种方式 vs post_* 参数注入

## 目标

为技术选型和框架理解提供参考依据，帮助团队理解两种建模范式的优劣与适用场景。