### PR TITLE
test: add core module tests + fix pagination limit propagation

### DIFF
--- a/src/nexusx/execution/query_executor.py
+++ b/src/nexusx/execution/query_executor.py
@@ -26,6 +26,7 @@ class _FieldJob:
     parent_entity: type[SQLModel]
     rel_info: RelationshipInfo
     child_sel: FieldSelection
+    original_sel: FieldSelection | None = None
 
 
 class QueryExecutor:
@@ -259,6 +260,7 @@ class QueryExecutor:
                     parent_entity=parent_entity,
                     rel_info=rel_info,
                     child_sel=effective_sel,
+                    original_sel=child_sel if effective_sel is not child_sel else None,
                 )
             )
         return jobs
@@ -335,10 +337,13 @@ class QueryExecutor:
         rel_info = job.rel_info
         child_sel = job.child_sel
 
-        # Extract page args from original field_sel (before items adjustment)
-        # The job.child_sel is already the items sub-selection;
-        # we need the original for pagination args.
-        page_args = self._extract_page_args(child_sel, rel_info)
+        # Extract page args from original field selection (before items adjustment).
+        # job.original_sel holds the original child_sel when it was replaced by
+        # items_sel; otherwise fall back to child_sel (no pagination adjustment).
+        page_args = self._extract_page_args(
+            job.original_sel if job.original_sel is not None else child_sel,
+            rel_info,
+        )
 
         target_rels = self._registry.get_relationships(rel_info.target_entity)
         fk_lookup = {name: info.fk_field for name, info in target_rels.items()}

--- a/tests/test_query_executor.py
+++ b/tests/test_query_executor.py
@@ -506,3 +506,235 @@ class TestQueryExecutorSplitMode:
         assert not isinstance(instance, dict)
         meta_fields = set(instance._query_meta["fields"])
         assert meta_fields == {"id", "name"}
+
+
+# ──────────────────────────────────────────────────────────
+# Additional coverage tests
+# ──────────────────────────────────────────────────────────
+
+
+class TestBuildFieldJobsEdgeCases:
+    def test_empty_sub_fields_returns_no_jobs(self):
+        """child_sel with empty sub_fields should produce no jobs."""
+        executor = _make_executor()
+        rel_info = executor._registry.get_relationship(FixtureTask, "owner")
+        assert rel_info is not None
+
+        # FieldSelection with no sub_fields (only scalar selected)
+        child_sel = FieldSelection(name="owner")
+        jobs = executor._build_field_jobs(
+            [FixtureTask(id=1, title="T", sprint_id=1, owner_id=1)],
+            FixtureTask,
+            FieldSelection(name="root", sub_fields={"owner": child_sel}),
+        )
+        assert jobs == []
+
+    def test_all_none_fk_values_returns_no_jobs(self):
+        """Parents with all-None FK values should produce no jobs."""
+        executor = _make_executor()
+        # FixtureTask with owner_id=None (FK not set)
+        task = FixtureTask(id=99, title="orphan", sprint_id=1, owner_id=None)
+        jobs = executor._build_field_jobs(
+            [task],
+            FixtureTask,
+            FieldSelection(name="root", sub_fields={
+                "owner": FieldSelection(name="owner", sub_fields={"id": FieldSelection(name="id")}),
+            }),
+        )
+        assert jobs == []
+
+    @pytest.mark.usefixtures("test_db")
+    async def test_resolve_result_with_none(self):
+        """_resolve_result should handle None result gracefully."""
+        executor = _make_executor()
+        # Should not raise
+        await executor._resolve_result(None, FixtureUser, FieldSelection(name="root"))
+
+    def test_pagination_items_without_sub_fields_produces_job_with_empty_sel(self):
+        """Paginated field with only pagination selected still produces a job
+        because child_sel.sub_fields is non-empty (has 'pagination')."""
+        executor = _make_executor(enable_pagination=True)
+        child_sel = FieldSelection(
+            name="tasks",
+            sub_fields={
+                "pagination": FieldSelection(name="pagination"),
+            },
+        )
+        jobs = executor._build_field_jobs(
+            [FixtureSprint(id=1, name="S1")],
+            FixtureSprint,
+            FieldSelection(name="root", sub_fields={"tasks": child_sel}),
+        )
+        # A job is created because child_sel.sub_fields is non-empty
+        assert len(jobs) == 1
+
+
+class TestQueryExecutorPagination:
+    @pytest.mark.usefixtures("test_db")
+    async def test_paginated_query_e2e(self):
+        """End-to-end paginated query should return items + pagination metadata."""
+        executor = _make_executor(enable_pagination=True)
+        session_factory = get_test_session_factory()
+
+        class SprintQuery(SQLModel, table=False):
+            @query
+            async def get_all(cls):
+                async with session_factory() as session:
+                    return list((await session.exec(select(FixtureSprint))).all())
+
+        method = _get_bound_method(SprintQuery, "get_all")
+        query_methods = {"sprints": (FixtureSprint, method)}
+        gql = "{ sprints { id name tasks { items { id title } pagination { total_count has_more } } } }"
+        parsed = QueryParser().parse(gql)
+
+        result = await executor.execute_query(
+            gql, None, None, parsed, query_methods, {},
+            [FixtureTask, FixtureUser, FixtureSprint],
+        )
+
+        sprints = result["data"]["sprints"]
+        assert len(sprints) == 2
+        for sprint in sprints:
+            page = sprint["tasks"]
+            assert "items" in page
+            assert len(page["items"]) == 2
+            assert "pagination" in page
+            assert page["pagination"]["total_count"] == 2
+
+    @pytest.mark.usefixtures("test_db")
+    async def test_paginated_query_respects_limit(self):
+        """limit argument should be propagated to paginated loader."""
+        executor = _make_executor(enable_pagination=True)
+        session_factory = get_test_session_factory()
+
+        class SprintQuery(SQLModel, table=False):
+            @query
+            async def get_all(cls):
+                async with session_factory() as session:
+                    return list((await session.exec(select(FixtureSprint))).all())
+
+        method = _get_bound_method(SprintQuery, "get_all")
+        query_methods = {"sprints": (FixtureSprint, method)}
+        gql = "{ sprints { id name tasks(limit: 1) { items { id title } pagination { total_count has_more } } } }"
+        parsed = QueryParser().parse(gql)
+
+        result = await executor.execute_query(
+            gql, None, None, parsed, query_methods, {},
+            [FixtureTask, FixtureUser, FixtureSprint],
+        )
+
+        sprints = result["data"]["sprints"]
+        for sprint in sprints:
+            page = sprint["tasks"]
+            assert len(page["items"]) == 1
+            assert page["pagination"]["total_count"] == 2
+            # end = offset(0) + 1 + 1 = 2, total = 2 → has_more = 2 > 2 = False
+            assert page["pagination"]["has_more"] is False
+
+
+class TestQueryExecutorSerializationExtras:
+    def test_serialize_without_field_sel_uses_model_dump(self):
+        """_serialize with no sub_fields should fall back to model_dump."""
+        executor = _make_executor()
+        user = FixtureUser(id=1, name="Alice", email="alice@test.com")
+        result = executor._serialize(user, FixtureUser, None)
+        assert isinstance(result, dict)
+        assert result["id"] == 1
+
+    def test_serialize_none_result(self):
+        """_serialize with None result should return None."""
+        executor = _make_executor()
+        assert executor._serialize(None, FixtureUser, None) is None
+
+    def test_serialize_list_result(self):
+        """_serialize with list result should return list of dicts."""
+        executor = _make_executor()
+        users = [
+            FixtureUser(id=1, name="Alice", email="a@t.com"),
+            FixtureUser(id=2, name="Bob", email="b@t.com"),
+        ]
+        result = executor._serialize(users, FixtureUser, None)
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    def test_serialize_entity_returns_none_for_none(self):
+        """_serialize_entity should return None for None input."""
+        executor = _make_executor()
+        assert executor._serialize_entity(None, FixtureUser, None) is None
+
+    def test_serialize_entity_passes_through_dict(self):
+        """_serialize_entity should pass through dict values."""
+        executor = _make_executor()
+        assert executor._serialize_entity({"id": 1}, FixtureUser, None) == {"id": 1}
+
+    def test_serialize_relationship_value_none(self):
+        """_serialize_relationship_value should return None for None value."""
+        executor = _make_executor()
+        rel_info = RelationshipInfo(
+            name="owner", direction="MANYTOONE", fk_field="owner_id",
+            target_entity=FixtureUser, is_list=False, loader=object,
+        )
+        assert executor._serialize_relationship_value(
+            None, rel_info, FieldSelection(name="owner")
+        ) is None
+
+    def test_get_fk_fields(self):
+        """_get_fk_fields should return FK field names."""
+        executor = _make_executor()
+        fk_fields = executor._get_fk_fields(FixtureTask)
+        assert "sprint_id" in fk_fields
+        assert "owner_id" in fk_fields
+
+    def test_get_relationship_names(self):
+        """_get_relationship_names should return relationship field names."""
+        executor = _make_executor()
+        rel_names = executor._get_relationship_names(FixtureTask)
+        assert "sprint" in rel_names
+        assert "owner" in rel_names
+
+    def test_paginated_serialization_with_pydantic_pagination(self):
+        """Pagination as Pydantic model should be serialized via model_dump."""
+        from nexusx.loader.pagination import Pagination
+
+        executor = _make_executor(enable_pagination=True)
+        rel_info = RelationshipInfo(
+            name="tasks", direction="ONETOMANY", fk_field="sprint_id",
+            target_entity=FixtureTask, is_list=True, loader=object,
+        )
+        child_sel = QueryParser().parse(
+            "{ posts { pagination { total_count has_more } } }"
+        )["posts"]
+
+        result = executor._serialize_relationship_value(
+            value={
+                "items": [],
+                "pagination": Pagination(has_more=False, total_count=5),
+            },
+            rel_info=rel_info,
+            child_sel=child_sel,
+        )
+        assert result["pagination"]["total_count"] == 5
+        assert result["pagination"]["has_more"] is False
+
+    def test_paginated_serialization_all_pagination_fields(self):
+        """Pagination with no sub-field filter should return all fields."""
+        executor = _make_executor(enable_pagination=True)
+        rel_info = RelationshipInfo(
+            name="tasks", direction="ONETOMANY", fk_field="sprint_id",
+            target_entity=FixtureTask, is_list=True, loader=object,
+        )
+        # pagination selected but no sub_fields → return all pagination fields
+        child_sel = FieldSelection(
+            name="tasks",
+            sub_fields={"pagination": FieldSelection(name="pagination")},
+        )
+
+        result = executor._serialize_relationship_value(
+            value={
+                "items": [],
+                "pagination": {"total_count": 3, "has_more": True},
+            },
+            rel_info=rel_info,
+            child_sel=child_sel,
+        )
+        assert result["pagination"] == {"total_count": 3, "has_more": True}

--- a/tests/test_response_builder.py
+++ b/tests/test_response_builder.py
@@ -138,3 +138,164 @@ class TestGetRelationEntity:
         # get_relation_entity extracts the type from annotations;
         # scalar fields are not filtered here
         assert entity is not None
+
+
+# ──────────────────────────────────────────────────────────
+# Additional coverage tests
+# ──────────────────────────────────────────────────────────
+
+from typing import Optional, get_args, get_origin
+
+from nexusx.response_builder import (
+    _build_scalar_model,
+    _extract_entity_from_annotation,
+    _is_list_relationship,
+    _resolve_forward_reference,
+    _validate_and_dump,
+)
+
+
+class TestBuildResponseModelExtras:
+    def test_unknown_relation_falls_back_to_any(self):
+        """When get_relation_entity returns None, field type falls back to Any."""
+        # Use RBPost with a non-existent relationship in field_tree
+        field_tree = {"id": None, "nonexistent_rel": {"id": None}}
+        model = build_response_model(RBPost, field_tree)
+        assert issubclass(model, BaseModel)
+        # The field should exist (with Any type)
+        assert "nonexistent_rel" in model.model_fields
+
+    def test_list_relationship_generates_list_type(self):
+        """List relationships should generate list[nested_model] fields."""
+        field_tree = {"id": None, "posts": {"id": None, "title": None}}
+        model = build_response_model(RBUser, field_tree)
+        assert "posts" in model.model_fields
+
+
+class TestValidateAndDump:
+    def test_none_value_returns_none(self):
+        """_validate_and_dump should return None for None input."""
+        model = build_response_model(RBUser, {"id": None, "name": None})
+        assert _validate_and_dump(model, None, None) is None
+
+    def test_dict_input(self):
+        """_validate_and_dump should handle dict input."""
+        model = build_response_model(RBUser, {"id": None, "name": None})
+        result = _validate_and_dump(model, {"id": 1, "name": "Alice"}, None)
+        assert result["id"] == 1
+
+    def test_validation_fallback_returns_filtered_data(self):
+        """When model_validate fails, should return filtered dict."""
+        model = build_response_model(RBUser, {"id": None, "name": None})
+        # Pass a value that won't validate — integer triggers except path
+        result = _validate_and_dump(model, 42, None)
+        # Falls through to return the raw value
+        assert result == 42
+
+    def test_nested_relationship_serialization(self):
+        """Nested field_tree should trigger recursive serialization."""
+        user = RBUser(id=1, name="Alice", email="alice@test.com")
+        field_tree = {"id": None, "posts": {"id": None, "title": None}}
+        result = serialize_with_model(user, RBUser, field_tree)
+        assert isinstance(result, dict)
+        assert result["id"] == 1
+
+
+class TestResolveForwardReference:
+    def test_simple_name_match(self):
+        """Simple annotation string should resolve to matching class."""
+        result = _resolve_forward_reference("RBUser", {RBUser, RBPost})
+        assert result is RBUser
+
+    def test_quoted_list_format(self):
+        """list['EntityName'] format should resolve."""
+        result = _resolve_forward_reference("list['RBUser']", {RBUser, RBPost})
+        assert result is RBUser
+
+    def test_unquoted_list_format(self):
+        """list[EntityName] format should resolve."""
+        result = _resolve_forward_reference("list[RBUser]", {RBUser, RBPost})
+        assert result is RBUser
+
+    def test_no_match_returns_none(self):
+        """Unknown annotation should return None."""
+        result = _resolve_forward_reference("NonExistent", {RBUser, RBPost})
+        assert result is None
+
+    def test_no_brackets_no_match(self):
+        """String without brackets that doesn't match returns None."""
+        result = _resolve_forward_reference("SomeOtherClass", {RBUser})
+        assert result is None
+
+
+class TestExtractEntityFromAnnotation:
+    def test_optional_entity(self):
+        """Optional[Entity] should extract Entity."""
+        result = _extract_entity_from_annotation(Optional[RBUser])
+        assert result is RBUser
+
+    def test_list_entity(self):
+        """list[Entity] should extract Entity."""
+        result = _extract_entity_from_annotation(list[RBUser])
+        assert result is RBUser
+
+    def test_direct_type(self):
+        """Direct type annotation should return the type."""
+        result = _extract_entity_from_annotation(RBUser)
+        assert result is RBUser
+
+    def test_string_forward_ref_with_subclasses(self):
+        """String forward reference should resolve with all_subclasses."""
+        result = _extract_entity_from_annotation("RBUser", {RBUser, RBPost})
+        assert result is RBUser
+
+    def test_no_match_returns_none(self):
+        """Unresolvable annotation should return None."""
+        result = _extract_entity_from_annotation(42)
+        assert result is None
+
+    def test_none_type_skipped_in_union(self):
+        """NoneType in Union args should be skipped."""
+        result = _extract_entity_from_annotation(RBUser | None)
+        assert result is RBUser
+
+
+class TestIsListRelationship:
+    def test_list_annotation(self):
+        """list[...] annotation should be detected."""
+        # RBPost.author is Optional[RBUser] — not a list
+        # Need a model with a resolved list[Entity] annotation
+        from typing import get_origin
+
+        # Verify the function works with a direct list type
+        class ListEntity(SQLModel, table=False):
+            items: list[int]
+
+        assert _is_list_relationship(ListEntity, "items") is True
+
+    def test_non_list_annotation(self):
+        """Non-list annotation should not be detected."""
+        assert _is_list_relationship(RBPost, "author") is False
+
+    def test_nonexistent_field(self):
+        """Non-existent field should return False."""
+        assert _is_list_relationship(RBUser, "nonexistent") is False
+
+
+class TestBuildScalarModelExtras:
+    def test_excludes_relationship_fields(self):
+        """Scalar model should exclude relationship fields."""
+        model = _build_scalar_model(RBPost, "Test")
+        assert "id" in model.model_fields
+        assert "title" in model.model_fields
+        # author is a relationship, should be excluded
+        assert "author" not in model.model_fields
+
+    def test_includes_all_scalar_fields(self):
+        """Scalar model should include all non-relationship fields."""
+        model = _build_scalar_model(RBUser, "Test")
+        field_names = set(model.model_fields.keys())
+        assert "id" in field_names
+        assert "name" in field_names
+        assert "email" in field_names
+        assert "posts" not in field_names

--- a/tests/test_sdl_generator.py
+++ b/tests/test_sdl_generator.py
@@ -445,3 +445,112 @@ class TestSDLGeneratorOperationSDL:
         assert sdl is not None
         assert "ArticleForTest" in sdl
         assert "AuthorForTest" in sdl
+
+
+# ──────────────────────────────────────────────────────────
+# Additional coverage tests
+# ──────────────────────────────────────────────────────────
+
+
+class TestSDLGeneratorExtras:
+    def test_empty_list_type_converts_to_string(self):
+        """list without type args falls through to String! (non-list branch)."""
+        converter = TypeConverter({"EntityForHelperTest"})
+        result = _python_type_to_graphql(list, converter)
+        # list (bare) has no origin match for list, so it falls through
+        assert result == "String!"
+
+    def test_pagination_types_generated(self):
+        """enable_pagination=True should produce Pagination and Result types."""
+        from tests.conftest import FixtureSprint, FixtureTask, FixtureUser
+        from nexusx.loader.registry import ErManager
+
+        registry = ErManager(
+            entities=[FixtureSprint, FixtureTask, FixtureUser],
+            session_factory=lambda: None,
+            enable_pagination=True,
+        )
+        generator = SDLGenerator([FixtureSprint, FixtureTask, FixtureUser])
+        sdl = generator.generate(enable_pagination=True, loader_registry=registry)
+
+        assert "type Pagination" in sdl
+        assert "has_more: Boolean!" in sdl
+        assert "total_count: Int" in sdl
+        assert "FixtureTaskResult" in sdl
+
+    def test_no_pagination_types_when_disabled(self):
+        """Without enable_pagination, no Pagination type should appear."""
+        generator = SDLGenerator([UserForTest])
+        sdl = generator.generate()
+        assert "type Pagination" not in sdl
+
+    def test_generate_input_type_skips_underscore_fields(self):
+        """Fields starting with _ should be excluded from input types."""
+
+        class UnderscoreEntity(SQLModel):
+            _private: str = ""
+            id: int | None
+            name: str
+
+        generator = SDLGenerator([UnderscoreEntity])
+        # _generate_input_type is called internally
+        sdl = generator.generate()
+        # The entity type should not include _private
+        assert "_private" not in sdl
+
+    def test_generate_with_no_query_methods(self):
+        """Entity without @query/@mutation should produce only type definition."""
+
+        class SimpleEntity(SQLModel):
+            id: int | None
+            value: str
+
+        generator = SDLGenerator([SimpleEntity])
+        sdl = generator.generate()
+        assert "type SimpleEntity" in sdl
+        assert "type Query" not in sdl
+
+    def test_method_default_params_are_optional(self):
+        """Method params with defaults should be optional (no !) in SDL."""
+
+        class DefaultParamEntity(SQLModel):
+            id: int | None
+
+            @query
+            async def search(cls, limit: int = 10, offset: int = 0) -> list["DefaultParamEntity"]:
+                return []
+
+        generator = SDLGenerator([DefaultParamEntity])
+        sdl = generator.generate()
+        # Optional params should not have !
+        assert "limit: Int" in sdl
+        assert "offset: Int" in sdl
+        # Should not have limit: Int!
+        assert "limit: Int!" not in sdl
+
+    def test_generate_operation_sdl_with_missing_return_type(self):
+        """Method with unresolvable return type should still generate SDL."""
+
+        class NoReturnEntity(SQLModel):
+            id: int | None
+
+            @query
+            def get_all(cls):
+                return []
+
+        generator = SDLGenerator([NoReturnEntity])
+        sdl = generator.generate_operation_sdl("noReturnEntityGetAll", "Query")
+        assert sdl is not None
+        assert "noReturnEntityGetAll" in sdl
+
+    def test_collect_related_entities_unreachable(self):
+        """Type hint referencing non-entity should not crash."""
+
+        class IsolatedEntity(SQLModel):
+            id: int | None
+            name: str
+
+        generator = SDLGenerator([IsolatedEntity])
+        # generate_operation_sdl internally calls _collect_related_entities
+        sdl = generator.generate_operation_sdl("nonExistent", "Query")
+        assert sdl is None


### PR DESCRIPTION
## Summary

- **Bug fix**: `QueryExecutor` was silently discarding the `limit` argument in paginated GraphQL queries (e.g. `tasks(limit: 1)` returned all results). `_FieldJob` now preserves the original field selection so `_load_field_paginated` can extract pagination args correctly.
- **+46 tests** for `query_executor`, `response_builder`, and `sdl_generator`

## Coverage impact

| Module | Before | After |
|--------|--------|-------|
| `execution/query_executor.py` | 73% | **98%** |
| `response_builder.py` | 74% | **90%** |
| `sdl_generator.py` | 82% | **88%** |

## Test plan

- [x] `uv run pytest` — 917 passed, 0 failed
- [x] `uv run ruff check src/ tests/` — clean
- [x] Verified `tasks(limit: 1)` now correctly returns 1 item via e2e test