### PR TITLE
feat: export AutoLoad in public API

### DIFF
--- a/src/nexusx/__init__.py
+++ b/src/nexusx/__init__.py
@@ -54,7 +54,7 @@ Example (Core API mode):
 
 from __future__ import annotations
 
-from nexusx.context import Collector, ExposeAs, SendTo
+from nexusx.context import AutoLoad, Collector, ExposeAs, SendTo
 from nexusx.decorator import mutation, query
 from nexusx.er_diagram import ErDiagram
 from nexusx.handler import GraphQLHandler
@@ -109,6 +109,7 @@ __all__ = [
     "ExposeAs",
     "SendTo",
     "Collector",
+    "AutoLoad",
     # Custom relationships
     "Relationship",
     "ErDiagram",


### PR DESCRIPTION
## Summary

- Export `AutoLoad` from `nexusx.context` in top-level `__init__.py` and `__all__`
- `AutoLoad(origin=)` allows users to override the relationship name when the DTO field name differs from the registered relationship name in ErManager

## Test plan

- [ ] Verify `from nexusx import AutoLoad` works
- [ ] Verify existing `ExposeAs`/`SendTo`/`Collector` imports still work
- [ ] Run `uv run pytest` to confirm no regressions

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)