### PR TITLE
fix: raise ValueError on ambiguous loader lookup

### DIFF
--- a/src/nexusx/loader/registry.py
+++ b/src/nexusx/loader/registry.py
@@ -433,7 +433,7 @@ class ErManager:
 
         Searches all registered entities for a relationship with the given name.
         Returns the first match, or None if not found.
-        Logs a warning if multiple entities have the same relationship name.
+        Raises ValueError if multiple entities have the same relationship name.
 
         Used by Resolver for Core API mode Loader() parameter injection.
         Prefer get_loader_for_entity() when the source entity is known.
@@ -449,11 +449,10 @@ class ErManager:
 
         if len(matches) > 1:
             entity_names = [e.__name__ for e, _ in matches]
-            logger.warning(
-                "Ambiguous loader lookup: relationship '%s' found on %s. "
-                "Returning first match (%s). Use Loader() with a DefineSubset "
-                "DTO or get_loader_for_entity() for precision.",
-                name, entity_names, entity_names[0],
+            raise ValueError(
+                f"Ambiguous loader lookup: relationship '{name}' found on "
+                f"{entity_names}. Use a DefineSubset DTO or "
+                f"get_loader_for_entity() for precision."
             )
 
         _, rel_info = matches[0]

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -241,8 +241,8 @@ class AmbigTarget(SQLModel, table=True):
 
 
 class TestGetLoaderByNameAmbiguity:
-    async def test_ambiguous_name_logs_warning(self, caplog):
-        """get_loader_by_name should log a warning when name is ambiguous."""
+    async def test_ambiguous_name_raises_error(self):
+        """get_loader_by_name should raise ValueError when name is ambiguous."""
 
         async def session_factory():
             pass  # Won't be called
@@ -252,12 +252,8 @@ class TestGetLoaderByNameAmbiguity:
             session_factory=session_factory,
         )
 
-        with caplog.at_level(logging.WARNING, logger="nexusx.loader.registry"):
-            loader = registry.get_loader_by_name("items")
-
-        assert loader is not None
-        assert "Ambiguous loader lookup" in caplog.text
-        assert "items" in caplog.text
+        with pytest.raises(ValueError, match="Ambiguous loader lookup.*items"):
+            registry.get_loader_by_name("items")
 
     async def test_unique_name_no_warning(self, caplog):
         """get_loader_by_name should not warn when name is unique."""


### PR DESCRIPTION
## Summary

- `ErManager.get_loader_by_name` 在多个实体有同名关系时，从 `logger.warning` + 返回第一个匹配，改为 `raise ValueError`
- 强制调用方使用 `get_loader_for_entity()` 或 `DefineSubset DTO` 明确指定，防止静默加载错误数据
- 更新对应测试：`test_ambiguous_name_logs_warning` → `test_ambiguous_name_raises_error`

Closes #43

## Test plan

- [x] `tests/test_fixes.py::TestGetLoaderByNameAmbiguity` — 歧义场景抛 ValueError，唯一名场景正常返回
- [x] 全量 917 passed，无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)