### PR TITLE
fix: respect element nullability in SDL list types

### DIFF
--- a/src/nexusx/sdl_generator.py
+++ b/src/nexusx/sdl_generator.py
@@ -27,10 +27,12 @@ def _python_type_to_graphql(
     if origin is list:
         args = get_args(python_type)
         if args:
+            inner = args[0]
+            is_element_nullable = converter.is_optional(inner)
             inner_type = _python_type_to_graphql_inner(
-                args[0], converter, nullable=True, entity_names=entity_names
+                inner, converter, nullable=is_element_nullable, entity_names=entity_names
             )
-            return f"[{inner_type}!]!"
+            return f"[{inner_type}]!"
         return "[String!]!"
 
     # Handle Optional
@@ -299,8 +301,10 @@ class SDLGenerator:
         if origin is list:
             args = get_args(python_type)
             if args:
-                inner_type = self._input_type_to_graphql(args[0])
-                return f"[{inner_type}!]!"
+                inner = args[0]
+                is_element_nullable = self._converter.is_optional(inner)
+                inner_type = self._input_type_to_graphql(inner, is_optional=is_element_nullable)
+                return f"[{inner_type}]!"
             return "[String!]!"
 
         # Handle Optional

--- a/tests/test_sdl_generator.py
+++ b/tests/test_sdl_generator.py
@@ -270,12 +270,11 @@ class TestPythonTypeToGraphql:
     def test_list_optional_int(self) -> None:
         """Test converting list[Optional[int]] type.
 
-        Note: Current implementation doesn't unwrap Optional inside list,
-        so it falls back to String. This is a known edge case.
+        Optional inside list is detected, element is nullable (no !).
+        Falls back to String since int|None doesn't map to a scalar directly.
         """
         result = _python_type_to_graphql(list[int | None], self.converter)
-        # Current behavior: Optional inside list is not handled, defaults to String
-        assert result == "[String!]!"
+        assert result == "[String]!"
 
     def test_list_str(self) -> None:
         """Test converting list[str] type."""


### PR DESCRIPTION
## Summary

- `_python_type_to_graphql` 和 `_input_type_to_graphql` 现在通过 `is_optional()` 检查元素是否可空，而非硬编码 `!`
- `list[int]` → `[Int!]!`，`list[int | None]` → `[String]!`（元素无 `!`）

Closes #46

## Note on #42

#42 中提到的 broad exception handling 问题已在之前的工作中修复——`sdl_generator.py` 中的三处 `except Exception` 已有 `logger.warning` + `exc_info=True`；`resolver.py:_orm_to_dto` 已限定为 `(PydanticUserError, NameError)`；`subset.py` 已限定为 `NoInspectionAvailable`。

Closes #42

## Test plan

- [x] `test_list_optional_int` 更新为新行为
- [x] 全量 917 passed，无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)