### PR TITLE
perf(graphql): cache relationship lookup in _serialize_item

### DIFF
--- a/src/nexusx/execution/query_executor.py
+++ b/src/nexusx/execution/query_executor.py
@@ -421,9 +421,10 @@ class QueryExecutor:
                 return self._filter_output(item.model_dump(mode="json"), entity)
             return {"_value": str(item)}
 
+        entity_rels = self._registry.get_relationships(entity)
         result = {}
         for field_name, child_sel in field_sel.sub_fields.items():
-            rel_info = self._registry.get_relationship(entity, field_name)
+            rel_info = entity_rels.get(field_name)
 
             if rel_info is not None:
                 value = self._retrieve(item, field_name)


### PR DESCRIPTION
## Summary

- Replace per-field `get_relationship()` calls (Python method call + two `dict.get` each) with a single `get_relationships()` call per entity in `_serialize_item`, then local `dict.get` in the serialization loop
- Reduces Python method call overhead from **N calls per entity** to **1 call per entity** (N = number of selected fields), remaining lookups use built-in `dict.get`

Closes #70

## Benchmark

### Micro-benchmark: `_serialize` isolated (Q4, 50 users, 1000+ rows)

5000 iterations, GC disabled, trimmed 5% outliers each end.

| | Avg | P50 | P95 | Min | StdDev |
|---|---|---|---|---|---|
| **Baseline (master)** | 1.334ms | 1.297ms | 1.426ms | 1.190ms | 57us |
| **Optimized** | 1.157ms | 1.131ms | 1.225ms | 1.096ms | 35us |
| **Delta** | **-13.3%** | **-12.8%** | **-14.1%** | **-8.2%** | - |

`_serialize` 热路径提升 **13%**。

### Full-query: XL scale (200 users, 100 sprints, 20000 tasks, 30 runs)

| Scenario | Baseline P50 | Optimized P50 | Delta |
|---|---|---|---|
| Q1: 1-level (task→owner) | 222.3ms | 217.9ms | -2.0% |
| Q2: 2-level (sprint→tasks→owner) | 236.6ms | 233.9ms | -1.1% |
| Q3: wide (user→posts+comments) | 18.4ms | 19.8ms | ~same |
| Q4: deep+wide | 82.5ms | 83.9ms | ~same |

`_serialize` 只占全链路 ~1% 时间（1.3ms / 90-240ms），13% 的 serialize 提升在全链路上 < 0.2%，被 SQLite async I/O 噪声（SD ≈ 20ms）淹没。对 MySQL 等真实数据库，I/O 占比更大，serialize 提升更难观测。

## Test plan

- [x] `uv run pytest` — 925 passed, 6 skipped
- [x] `uv run python benchmarks/bench_graphql.py` — correctness verification passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)