### PR TITLE
perf: _orm_to_dto cached fields + remove _serialize_entity wrapper

### DIFF
--- a/src/nexusx/execution/query_executor.py
+++ b/src/nexusx/execution/query_executor.py
@@ -447,6 +447,8 @@ class QueryExecutor:
         if value is None:
             return None
 
+        target = rel_info.target_entity
+
         if (
             self._enable_pagination
             and rel_info.is_list
@@ -460,11 +462,10 @@ class QueryExecutor:
             wants_items = child_sel.sub_fields is not None and "items" in child_sel.sub_fields
             if wants_items:
                 items_sel = child_sel.sub_fields.get("items") if child_sel.sub_fields else None
-                serialized_items = [
-                    self._serialize_entity(v, rel_info.target_entity, items_sel)
-                    for v in items
+                page_result["items"] = [
+                    self._serialize_item(v, target, items_sel)
+                    for v in items if v is not None
                 ]
-                page_result["items"] = serialized_items
             # Only include pagination if the user selected it in the query
             wants_pagination = (
                 child_sel.sub_fields is not None and "pagination" in child_sel.sub_fields
@@ -489,24 +490,13 @@ class QueryExecutor:
 
         if isinstance(value, list):
             return [
-                self._serialize_entity(v, rel_info.target_entity, child_sel)
-                for v in value
+                self._serialize_item(v, target, child_sel)
+                for v in value if v is not None
             ]
 
-        return self._serialize_entity(value, rel_info.target_entity, child_sel)
-
-    def _serialize_entity(
-        self,
-        item: Any,
-        entity: type[SQLModel],
-        field_sel: FieldSelection | None,
-    ) -> dict[str, Any] | None:
-        """Serialize a single entity with nested fields."""
-        if item is None:
-            return None
-        if isinstance(item, dict):
-            return item
-        return self._serialize_item(item, entity, field_sel)
+        if isinstance(value, dict):
+            return value
+        return self._serialize_item(value, target, child_sel)
 
     def _filter_output(
         self, data: dict[str, Any], entity: type[SQLModel]

--- a/src/nexusx/resolver.py
+++ b/src/nexusx/resolver.py
@@ -467,30 +467,30 @@ class Resolver:
             return anno
         return None
 
-    @staticmethod
-    def _orm_to_dto(orm_instance: Any, dto_cls: type[BaseModel]) -> BaseModel:
+    # Cache: dto_cls -> pre-built subset_fields tuple (or None for model_validate path)
+    _dto_fields_cache: dict[type, tuple[str, ...] | None] = {}
+
+    @classmethod
+    def _orm_to_dto(cls, orm_instance: Any, dto_cls: type[BaseModel]) -> BaseModel:
         """Convert a SQLModel ORM instance to a DefineSubset DTO."""
-        subset_fields = getattr(dto_cls, "__subset_fields__", None)
+        subset_fields = cls._dto_fields_cache.get(dto_cls)
+        if subset_fields is None and dto_cls not in cls._dto_fields_cache:
+            subset_fields = getattr(dto_cls, "__subset_fields__", None)
+            cls._dto_fields_cache[dto_cls] = subset_fields
+
         if subset_fields is None:
             return dto_cls.model_validate(orm_instance)
-        kwargs = {}
-        for fname in subset_fields:
-            val = getattr(orm_instance, fname, None)
-            if val is not None:
-                kwargs[fname] = val
+
+        kwargs = {f: v for f in subset_fields if (v := getattr(orm_instance, f, None)) is not None}
         try:
             return dto_cls(**kwargs)
         except (PydanticUserError, NameError):
-            # Handle forward references from __future__ import annotations.
-            # Build a namespace with all known DefineSubset DTOs so
-            # model_rebuild can resolve type names like 'UserDTO'.
             import sys
 
             from nexusx.subset import _subset_registry
 
             module = sys.modules.get(dto_cls.__module__, None)
             ns = dict(vars(module)) if module else {}
-            # Add all known DefineSubset DTOs to the namespace
             for dto_class in _subset_registry:
                 ns[dto_class.__name__] = dto_class
             dto_cls.model_rebuild(_types_namespace=ns)

--- a/tests/test_query_executor.py
+++ b/tests/test_query_executor.py
@@ -719,15 +719,16 @@ class TestQueryExecutorSerializationExtras:
         assert isinstance(result, list)
         assert len(result) == 2
 
-    def test_serialize_entity_returns_none_for_none(self):
-        """_serialize_entity should return None for None input."""
+    def test_serialize_item_returns_none_for_none(self):
+        """_serialize_item should return None-filtered result (via _serialize)."""
         executor = _make_executor()
-        assert executor._serialize_entity(None, FixtureUser, None) is None
+        # _serialize handles None at top level
+        assert executor._serialize(None, FixtureUser, None) is None
 
-    def test_serialize_entity_passes_through_dict(self):
-        """_serialize_entity should pass through dict values."""
+    def test_serialize_item_passes_through_dict(self):
+        """_serialize_item should pass through dict values."""
         executor = _make_executor()
-        assert executor._serialize_entity({"id": 1}, FixtureUser, None) == {"id": 1}
+        assert executor._serialize_item({"id": 1}, FixtureUser, None) == {"id": 1}
 
     def test_serialize_relationship_value_none(self):
         """_serialize_relationship_value should return None for None value."""


### PR DESCRIPTION
## Summary

- **resolver.py**：`_orm_to_dto` 用类级别 dict 缓存 `subset_fields`，避免每次 `getattr(dto_cls, "__subset_fields__", None)`。kwargs 构造改为 dict comprehension。
- **query_executor.py**：删除 `_serialize_entity` 方法——其 None/dict 检查已被 `_serialize_relationship_value` 覆盖，直接调 `_serialize_item` 省掉每实体一次 Python 函数调用帧。

Closes #72

## Benchmark

### `_serialize` 微基准（Q4, 50 users, 1000+ rows, 5000 runs, GC off, trimmed 10%）

| | Avg | P50 | P95 |
|---|---|---|---|
| 原始基线 | 1.334ms | 1.297ms | 1.426ms |
| #73 后 | 1.157ms | 1.131ms | 1.225ms |
| **本 PR** | **1.127ms** | **1.088ms** | **1.214ms** |
| 累计 vs 基线 | **-15.5%** | **-16.1%** | **-14.9%** |

本 PR 在 #73 基础上再降 **~2.6%**（去掉 `_serialize_entity` 函数调用帧）。

### Resolver L3/L4（50 users, 1000 tasks, 2000 runs）

全链路被 SQL + DataLoader I/O 主导（SD ≈ 3ms），Python 层优化在噪声内。

## Test plan

- [x] `uv run pytest` — 925 passed, 6 skipped
- [x] 更新 `test_query_executor.py` 中已删除的 `_serialize_entity` 测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)