### PR TITLE
feat(router): add extensibility to create_router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## 2.10.0
+
+### New Feature: Resolver `post_default_handler` 收尾钩子
+
+新增保留方法 `post_default_handler(self)`，在该节点所有 `post_*` 方法执行完毕后运行，用于跨多个 `post_*` 字段的聚合 / 收尾计算（如根据多个计数算 completion_rate、拼接 summary）。语义对齐 pydantic-resolve 的同名特性。
+
+**行为：**
+- 固定方法名 `post_default_handler`（非 `post_<field>`，不绑定到某个字段）
+- 在同节点所有 `post_*` 完成后执行（可安全读取它们写入的字段）
+- **不自动赋值**：返回值被忽略，方法体内手动 `self.xxx = ...`（可一次写多个字段）
+- 支持与 `post_*` 相同的参数注入：`context` / `parent` / `ancestor_context` / `Loader` / `Collector`，可为 `async`
+- 由于 BFS 递归先于 `post_*` 阶段，`post_default_handler` 能读到后代 `SendTo` 已经收集进祖先 Collector 的值
+
+**与 pydantic-resolve 的差异：** nexusx 额外允许在 `post_default_handler` 中使用 `Loader`（pydantic-resolve 显式禁用），保持与 `post_*` 内部一致。
+
+**示例：**
+
+```python
+class SprintView(BaseModel):
+    total_tasks: int = 0
+    completed_tasks: int = 0
+    completion_rate: float = 0.0
+    summary: str = ""
+
+    def post_total_tasks(self):
+        return len(self.tasks)
+
+    def post_completed_tasks(self):
+        return len([t for t in self.tasks if t.status == "done"])
+
+    def post_default_handler(self):
+        # runs after post_total_tasks / post_completed_tasks
+        self.completion_rate = (
+            self.completed_tasks / self.total_tasks
+            if self.total_tasks else 0.0
+        )
+        self.summary = f"{self.completion_rate:.0%} complete"
+```
+
+**Changes：**
+- `src/nexusx/resolver.py`: 新增 `POST_DEFAULT_HANDLER` 常量；`_ClassMeta` 增加 `post_default_handler` 字段；`_build_class_meta` 优先识别保留名（避免被 `post_*` 前缀分支误当成 `default_handler` 字段）；`_compute_should_traverse` 计入该方法（否则仅含该钩子的子节点不会被遍历）；`_execute_posts` 末尾追加一轮调用（不 setattr）
+- `tests/test_resolver.py`: 新增 `TestResolverPostDefaultHandler`（9 个测试覆盖执行顺序、返回值忽略、async、Collector、context、parent、ancestor_context、仅含 handler 的子节点遍历、多兄弟节点）
+- `CLAUDE.md`: 更新 Resolver 执行顺序（新增第 4 步）与常见陷阱（保留方法名）
+
 ## 2.9.2
 
 ### New Feature: DefineSubset FK 字段自动注入

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.9.2
+
+### New Feature: DefineSubset FK 字段自动注入
+
+FK 字段自动注入到 DTO（`model_fields`），供 Resolver 用作 DataLoader key 加载关系。与 PK auto-include 机制对称：字段存在但 `exclude=True`，不出现在 `model_dump()` 序列化输出中。`build_dto_select()` 自动排除这些字段，不生成多余的 SELECT 列。
+
+**行为：**
+- 未在 `__subset__` 中声明的 FK 字段自动注入，annotation 改为 `Optional`（`default=None`），`exclude=True`
+- 显式声明在 `__subset__` 中的 FK 字段保持原样，不受影响
+- `SubsetConfig(omit_fields=["owner_id"])` 可阻止 auto-include，但如果 DTO 同时声明了对应的关系字段（如 `owner: OwnerDTO`），会抛出 `ValueError`
+
+**Changes：**
+- `src/nexusx/subset.py`: 新增 `_get_fk_field_names()`；`_resolve_subset_fields` FK auto-include（尊重 `omit_fields`）；`_build_field_definitions` 对 auto-included FK 设 `Optional + default=None + exclude=True`；`_create_subset_class` 存 `__subset_auto_excluded__`；`build_dto_select` 排除 auto-excluded 字段；新增 `_validate_omitted_fk_not_needed()` 校验 omit FK 与关系字段冲突
+- 修正旧测试适配新行为；新增 2 个测试覆盖 omit FK 场景
+
 ## 2.9.1
 
 ### Bug Fix: `list[T] | None` 和 `list[T | None]` 类型转换错误

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2.9.1
+
+### Bug Fix: `list[T] | None` 和 `list[T | None]` 类型转换错误
+
+修复 `_python_type_to_graphql` 中 Optional 与 list 组合类型的 GraphQL SDL 生成错误。
+
+**根因：** `_python_type_to_graphql` 先检查 `origin is list`，再检查 Optional。对于 `list[str] | None`，`get_origin()` 返回 `UnionType` 而非 `list`，list 检查被跳过。Optional 分支 unwrap 后调用 `_python_type_to_graphql_inner`，而 `_inner` 不处理 list 类型，fallback 为 `String`。同理，`list[Entity | None]` 的元素类型也因 `_inner` 不处理 Optional 而 fallback 为 `String`。
+
+**影响：**
+- `list[str] | None` 参数/返回值 → SDL 中生成 `String` 而非 `[String!]`
+- `list[int] | None` 参数/返回值 → SDL 中生成 `String` 而非 `[Int!]`
+- `list[Entity | None]` 参数/返回值 → SDL 中元素类型丢失，fallback 为 `String`
+
+**Changes：**
+- `src/nexusx/sdl_generator.py`: Optional 分支改为递归调用 `_python_type_to_graphql`（而非 `_inner`），使 list 检查能再次命中；list 分支先 unwrap 元素的 Optional，再传给 `_inner`
+- 修正 `tests/test_sdl_generator.py::test_list_optional_int` 的错误期望（`[String]!` → `[Int]!`）
+- 新增 `tests/test_optional_list_param.py`：9 个测试覆盖 `list[str] | None`、`Optional[list[str]]`、`list[int] | None`、`list[str]`、`list[Entity | None]`、`list[str | None]` 及完整 SDL 生成
+
 ## 2.9.0
 
 ### Bug Fix: 自定义关系在全局分页下无法查询

--- a/demo/use_case/fastapi_auto.py
+++ b/demo/use_case/fastapi_auto.py
@@ -134,6 +134,39 @@ context_config = UseCaseAppConfig(
 )
 app.include_router(create_use_case_router(context_config))
 
+# ──────────────────────────────────────────────────
+# Advanced: dependencies + route_options
+# ──────────────────────────────────────────────────
+#
+# Router-level dependencies (e.g. auth) applied to all routes:
+#
+#   from fastapi import Depends, HTTPException, Request
+#
+#   async def require_auth(request: Request):
+#       if not request.headers.get("Authorization"):
+#           raise HTTPException(status_code=401, detail="Unauthorized")
+#
+#   app.include_router(
+#       create_use_case_router(
+#           config,
+#           dependencies=[Depends(require_auth)],
+#       ),
+#   )
+#
+# Per-route overrides (status_code, extra dependencies, response_model, etc.):
+#
+#   app.include_router(
+#       create_use_case_router(
+#           config,
+#           route_options={
+#               "UserService.create_user": {"status_code": 201},
+#               "SprintService.get_sprint_detail": {
+#                   "dependencies": [Depends(require_auth)],
+#               },
+#           },
+#       ),
+#   )
+
 
 if __name__ == "__main__":
     import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nexusx"
-version = "2.9.0"
+version = "2.9.1"
 description = "GraphQL SDL generation and query optimization for SQLModel"
 authors = [{ name = "tangkikodo", email = "allmonday@126.com" }]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nexusx"
-version = "2.9.2"
+version = "2.10.0"
 description = "GraphQL SDL generation and query optimization for SQLModel"
 authors = [{ name = "tangkikodo", email = "allmonday@126.com" }]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nexusx"
-version = "2.9.1"
+version = "2.9.2"
 description = "GraphQL SDL generation and query optimization for SQLModel"
 authors = [{ name = "tangkikodo", email = "allmonday@126.com" }]
 readme = "README.md"

--- a/src/nexusx/resolver.py
+++ b/src/nexusx/resolver.py
@@ -4,6 +4,13 @@ Traverses Pydantic/DefineSubset model trees, executing resolve_* methods
 to load related data and post_* methods to compute derived fields.
 Supports cross-layer data flow via ExposeAs, SendTo, and Collector.
 
+A reserved ``post_default_handler(self)`` method may be defined to run
+finalization logic after all ``post_*`` methods at the same node complete.
+Unlike ``post_*``, it is not auto-assigned to a field — the body must set
+fields manually (and may set several). It accepts the same parameter
+injection as ``post_*`` (context / parent / ancestor_context / Loader /
+Collector) and may be ``async``.
+
 Uses the same ErManager as GraphQL mode for DataLoader access.
 Not intended for direct construction — use ``ErManager.create_resolver()``.
 
@@ -132,7 +139,10 @@ class _ClassMeta:
     # attr_name -> pre-parsed parameter info
     resolve_params: dict[str, _MethodParamInfo] = field(default_factory=dict)
     post_params: dict[str, _MethodParamInfo] = field(default_factory=dict)
-    # Collector aliases found in post_* methods: alias -> flat
+    # Special post_default_handler method, if present: (attr_name, param_info).
+    # Runs after all post_* methods; return value is ignored.
+    post_default_handler: tuple[str, _MethodParamInfo] | None = None
+    # Collector aliases found in post_* / post_default_handler: alias -> flat
     collector_aliases: dict[str, bool] = field(default_factory=dict)
     # Whether this class or any descendant needs traversal.
     # None = not yet computed; True/False = computed result.
@@ -175,6 +185,9 @@ def _analyze_method_params(
 
 RESOLVE_PREFIX = "resolve_"
 POST_PREFIX = "post_"
+# Reserved method name (not a field-bound post_*): runs after all post_*
+# methods at the same node, does not auto-assign — body sets fields manually.
+POST_DEFAULT_HANDLER = "post_default_handler"
 
 
 def _build_class_meta(kls: type) -> _ClassMeta:
@@ -182,6 +195,19 @@ def _build_class_meta(kls: type) -> _ClassMeta:
     meta = _ClassMeta()
 
     for attr_name in dir(kls):
+        # Reserved name — must be checked BEFORE the post_* prefix branch,
+        # otherwise it would be treated as `post_default_handler` → field
+        # `default_handler` and auto-assigned.
+        if attr_name == POST_DEFAULT_HANDLER:
+            attr = getattr(kls, attr_name, None)
+            if attr is not None and callable(attr):
+                param_info = _analyze_method_params(attr, include_collectors=True)
+                meta.post_default_handler = (attr_name, param_info)
+                for _pname, collector in param_info.collector_deps:
+                    if collector.alias not in meta.collector_aliases:
+                        meta.collector_aliases[collector.alias] = collector.flat
+            continue
+
         if attr_name.startswith(RESOLVE_PREFIX):
             field_name = attr_name[len(RESOLVE_PREFIX):]
             # Verify it's actually callable (not just an attribute)
@@ -244,6 +270,7 @@ def _compute_should_traverse(kls: type) -> bool:
 
     # Check own configuration
     if (meta.resolve_methods or meta.post_methods or meta.collector_aliases
+            or meta.post_default_handler is not None
             or scan_expose_fields(kls) or scan_send_to_fields(kls)):
         return True
 
@@ -750,7 +777,15 @@ class Resolver:
                     ))
 
     async def _execute_posts(self, level_state: _LevelState) -> None:
-        """Phase 3: run all post_* methods."""
+        """Phase 3: run all post_* methods, then post_default_handler if present.
+
+        post_default_handler runs after every post_* method at this level has
+        finished (so it can read fields populated by them) and is not
+        auto-assigned — its body sets fields manually. It shares the same
+        parameter injection as post_* (context / parent / ancestor_context /
+        Loader / Collector); by this point descendant SendTo values have
+        already populated ancestor Collectors (recursion precedes this phase).
+        """
         for item, meta, _new_ancestor_ctx, _merged_collectors in level_state:
             if not meta.post_methods:
                 continue
@@ -762,6 +797,18 @@ class Resolver:
                     node, field_name, method, param_info,
                     parent=item.parent, ancestor_context=item.ancestor_context,
                 )
+
+        for item, meta, _new_ancestor_ctx, _merged_collectors in level_state:
+            if meta.post_default_handler is None:
+                continue
+            attr_name, param_info = meta.post_default_handler
+            node = item.node
+            method = getattr(node, attr_name)
+            # Return value intentionally ignored — the handler sets fields itself.
+            await self._execute_post_method(
+                node, method, param_info,
+                parent=item.parent, ancestor_context=item.ancestor_context,
+            )
 
     def _collect_send_to(
         self, level_state: _LevelState, type_meta: dict[type, _LevelMeta]

--- a/src/nexusx/sdl_generator.py
+++ b/src/nexusx/sdl_generator.py
@@ -29,6 +29,8 @@ def _python_type_to_graphql(
         if args:
             inner = args[0]
             is_element_nullable = converter.is_optional(inner)
+            if is_element_nullable:
+                inner = converter.unwrap_optional(inner)
             inner_type = _python_type_to_graphql_inner(
                 inner, converter, nullable=is_element_nullable, entity_names=entity_names
             )
@@ -38,9 +40,11 @@ def _python_type_to_graphql(
     # Handle Optional
     if converter.is_optional(python_type):
         inner = converter.unwrap_optional(python_type)
-        return _python_type_to_graphql_inner(
-            inner, converter, nullable=True, entity_names=entity_names
-        )
+        result = _python_type_to_graphql(inner, converter, entity_names=entity_names)
+        # Strip trailing '!' if present — Optional means nullable
+        if result.endswith("!"):
+            result = result[:-1]
+        return result
 
     # Non-nullable type
     return _python_type_to_graphql_inner(

--- a/src/nexusx/subset.py
+++ b/src/nexusx/subset.py
@@ -94,6 +94,15 @@ def _get_pk_field_names(entity: type[SQLModel]) -> list[str]:
     return pk_names
 
 
+def _get_fk_field_names(entity: type[SQLModel]) -> list[str]:
+    """Get foreign key field names from a SQLModel entity."""
+    fk_names: list[str] = []
+    for field_name, field_info in entity.model_fields.items():
+        if _is_fk_field(field_info):
+            fk_names.append(field_name)
+    return fk_names
+
+
 def _get_sqlmodel_scalar_fields(entity: type[SQLModel]) -> dict[str, FieldInfo]:
     """Get only scalar fields from a SQLModel entity (exclude relationships and FK fields)."""
     relationship_names = _get_relationship_names(entity)
@@ -325,6 +334,36 @@ def _validate_extra_field_types(
             )
 
 
+def _validate_omitted_fk_not_needed(
+    entity_kls: type[SQLModel],
+    subset_info: Any,
+    extra_fields: dict[str, tuple[Any, Any]],
+) -> None:
+    """Raise if a FK is in omit_fields but a relationship extra field needs it."""
+    if not isinstance(subset_info, SubsetConfig) or not subset_info.omit_fields:
+        return
+
+    fk_names = set(_get_fk_field_names(entity_kls))
+    omitted_fks = set(subset_info.omit_fields) & fk_names
+    if not omitted_fks:
+        return
+
+    rel_names = _get_all_relationship_names(entity_kls)
+    extra_rel_fields = set(extra_fields.keys()) & rel_names
+    if not extra_rel_fields:
+        return
+
+    for fk in omitted_fks:
+        # Convention: owner_id → owner, sprint_id → sprint
+        rel_name = fk.removesuffix("_id")
+        if rel_name in extra_rel_fields:
+            raise ValueError(
+                f"Cannot omit FK field '{fk}' from {entity_kls.__name__} subset: "
+                f"relationship field '{rel_name}' requires it for DataLoader resolution. "
+                f"Either remove '{rel_name}' from the DTO or remove '{fk}' from omit_fields."
+            )
+
+
 # ──────────────────────────────────────────────────────────
 # SubsetMeta metaclass
 # ──────────────────────────────────────────────────────────
@@ -469,9 +508,13 @@ class SubsetMeta(type):
             cls._merge_config_overrides(field_definitions, subset_info, local_ns, namespace)
 
         _validate_extra_field_types(extra_fields, entity_kls, global_ns, namespace)
+        _validate_omitted_fk_not_needed(
+            entity_kls, subset_info, extra_fields,
+        )
 
         return cls._create_subset_class(
             name, field_definitions, subset_fields, entity_kls, namespace,
+            auto_excluded,
         )
 
     @staticmethod
@@ -521,6 +564,17 @@ class SubsetMeta(type):
                 if pk in user_omit:
                     auto_excluded.add(pk)
 
+        # Auto-include FK fields for DataLoader key resolution (relationship loading).
+        # FK fields in user_omit are skipped — validation later checks for conflicts.
+        fk_fields = _get_fk_field_names(entity_kls)
+        for fk in fk_fields:
+            if fk in user_omit:
+                continue
+            if fk not in existing_set:
+                subset_fields.append(fk)
+                existing_set.add(fk)
+                auto_excluded.add(fk)
+
         return entity_kls, subset_fields, auto_excluded
 
     @staticmethod
@@ -544,13 +598,19 @@ class SubsetMeta(type):
         field_definitions.update(field_infos)
         field_definitions.update(extra_fields)
 
-        # Hide auto-included PK fields from serialization
+        # Hide auto-included PK/FK fields from serialization
         for field_name in auto_excluded:
             if field_name in field_definitions:
                 _anno, fi = field_definitions[field_name]
                 if isinstance(fi, FieldInfo):
                     new_fi = copy.deepcopy(fi)
                     new_fi.exclude = True
+                    # Make auto-included FK fields optional with default None
+                    if _is_fk_field(fi):
+                        from typing import Union as _Union
+
+                        _anno = _Union[_anno, type(None)]
+                        new_fi.default = None
                     field_definitions[field_name] = (_anno, new_fi)
 
         if isinstance(subset_info, SubsetConfig):
@@ -649,6 +709,7 @@ class SubsetMeta(type):
         subset_fields: list[str],
         entity_kls: type[SQLModel],
         namespace: dict,
+        auto_excluded: set[str] | None = None,
     ) -> Any:
         """Create the Pydantic model, attach methods and metadata."""
         methods = _extract_methods(namespace)
@@ -672,6 +733,7 @@ class SubsetMeta(type):
         setattr(subset_class, SUBSET_REFERENCE, entity_kls)
         _subset_registry[subset_class] = entity_kls
         subset_class.__subset_fields__ = list(subset_fields)
+        subset_class.__subset_auto_excluded__ = auto_excluded or set()
 
         return subset_class
 
@@ -758,9 +820,14 @@ def build_dto_select(
             f"{dto_cls.__name__} has no __subset_fields__"
         )
 
-    # Filter out relationship field names — they are not table columns
+    # Filter out relationship field names and auto-excluded fields —
+    # they are not needed in the SELECT statement.
     rel_names = _get_all_relationship_names(entity_cls)
-    column_fields = [f for f in subset_fields if f not in rel_names]
+    auto_excluded = getattr(dto_cls, "__subset_auto_excluded__", set())
+    column_fields = [
+        f for f in subset_fields
+        if f not in rel_names and f not in auto_excluded
+    ]
     columns = [getattr(entity_cls, f) for f in column_fields]
 
     stmt = select(*columns)

--- a/src/nexusx/use_case/router.py
+++ b/src/nexusx/use_case/router.py
@@ -7,7 +7,7 @@ methods in a ``UseCaseAppConfig``, with proper OpenAPI documentation and
 
 import inspect
 import re
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from typing import Annotated, Any, get_args, get_origin, get_type_hints
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -218,6 +218,10 @@ def create_router(
     config: UseCaseAppConfig,
     prefix: str = "/api",
     url_mapper: Callable[[type[UseCaseService]], str] | None = None,
+    *,
+    dependencies: Sequence[Any] | None = None,
+    route_options: dict[str, dict[str, Any]] | None = None,
+    **router_kwargs: Any,
 ) -> APIRouter:
     """Create a FastAPI APIRouter from a UseCaseAppConfig.
 
@@ -231,6 +235,24 @@ def create_router(
         url_mapper: Optional callable to customize per-service URL segment.
             Receives the service class, returns a string.
             Defaults to snake_case of the class name.
+        dependencies: Router-level dependencies applied to **all** routes
+            (e.g. ``[Depends(require_auth)]``). Passed directly to
+            ``APIRouter(dependencies=...)``.
+        route_options: Per-route overrides keyed by
+            ``"ServiceName.method_name"``. Values are merged into
+            ``add_api_route()`` kwargs, so you can set ``status_code``,
+            ``dependencies``, ``response_model``, ``responses``, etc.
+            Example::
+
+                {
+                    "UserService.create_user": {
+                        "status_code": 201,
+                        "dependencies": [Depends(require_admin)],
+                    },
+                }
+        **router_kwargs: Additional keyword arguments forwarded to the
+            ``APIRouter()`` constructor (e.g. ``default_response_class``,
+            ``responses``, ``deprecated``).
 
     Returns:
         A ``fastapi.APIRouter`` ready to be included in a FastAPI app.
@@ -245,7 +267,7 @@ def create_router(
         )
         app.include_router(router)
     """
-    router = APIRouter()
+    router = APIRouter(dependencies=dependencies, **router_kwargs)
 
     for service_cls in config.services:
         tag = service_cls.get_tag_name()
@@ -306,18 +328,24 @@ def create_router(
             path = f"{prefix}/{service_url}/{method_name}"
 
             # Register route
-            router_kwargs: dict[str, Any] = {
+            route_kwargs: dict[str, Any] = {
                 "path": path,
                 "tags": [tag],
                 "summary": description or method_name,
             }
             if return_type is not None:
-                router_kwargs["response_model"] = return_type
+                route_kwargs["response_model"] = return_type
+
+            # Merge per-route overrides from route_options
+            route_key = f"{service_cls.__name__}.{method_name}"
+            overrides = (route_options or {}).get(route_key)
+            if overrides:
+                route_kwargs.update(overrides)
 
             router.add_api_route(
                 endpoint=handler,
                 methods=["POST"],
-                **router_kwargs,
+                **route_kwargs,
             )
 
     return router

--- a/tests/test_autoload.py
+++ b/tests/test_autoload.py
@@ -378,11 +378,13 @@ class TestAutoLoadSubsetFields:
 
         assert "owner_id" in TaskDTO.__subset_fields__
 
-    def test_subset_fields_excludes_non_selected(self):
-        """__subset_fields__ should only include selected fields."""
+    def test_subset_fields_includes_auto_fks(self):
+        """__subset_fields__ should include auto-included PK and FK fields."""
 
         class TaskDTO(DefineSubset):
             __subset__ = (FixtureTask, ("id", "title"))
 
-        assert "owner_id" not in TaskDTO.__subset_fields__
-        assert TaskDTO.__subset_fields__ == ["id", "title"]
+        assert "owner_id" in TaskDTO.__subset_fields__
+        assert "sprint_id" in TaskDTO.__subset_fields__
+        # Auto-included FK fields are tracked in __subset_auto_excluded__
+        assert "owner_id" in TaskDTO.__subset_auto_excluded__

--- a/tests/test_optional_list_param.py
+++ b/tests/test_optional_list_param.py
@@ -1,0 +1,141 @@
+"""Regression test: list[str] | None parameter should produce [String], not String.
+
+Bug: _python_type_to_graphql() checks `origin is list` before checking Optional.
+For `list[str] | None`, `get_origin()` returns UnionType, not list, so the list
+check is skipped. Then Optional branch calls _python_type_to_graphql_inner() on
+the unwrapped `list[str]`, which doesn't handle list types — falling back to String.
+
+See: sdl_generator._python_type_to_graphql lines 20-48
+"""
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+from nexusx import mutation, query
+from nexusx.sdl_generator import SDLGenerator, _python_type_to_graphql
+from nexusx.type_converter import TypeConverter
+
+
+# ── Entity with list[str] | None parameter ────────────────────────────
+
+
+class ItemForListBug(SQLModel):
+    """Test entity with optional list parameter."""
+
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+
+    @mutation
+    async def create_with_optional_tags(
+        cls, name: str, tags: list[str] | None = None
+    ) -> "ItemForListBug":
+        """Create item with optional tag list."""
+        return ItemForListBug(id=1, name=name)
+
+    @mutation
+    async def create_with_required_tags(
+        cls, name: str, tags: list[str]
+    ) -> "ItemForListBug":
+        """Create item with required tag list."""
+        return ItemForListBug(id=1, name=name)
+
+    @mutation
+    async def create_with_optional_typing(
+        cls, name: str, tags: Optional[list[str]] = None
+    ) -> "ItemForListBug":
+        """Create item using Optional[list[str]] syntax."""
+        return ItemForListBug(id=1, name=name)
+
+    @query
+    async def search_optional_ints(
+        cls, ids: list[int] | None = None
+    ) -> list["ItemForListBug"]:
+        """Query with optional list[int]."""
+        return []
+
+
+# ── Tests ─────────────────────────────────────────────────────────────
+
+
+class TestOptionalListParameterBug:
+    """list[T] | None should serialize to [T!], not String."""
+
+    def setup_method(self) -> None:
+        self.converter = TypeConverter(set())
+
+    # --- Direct type conversion ---
+
+    def test_list_str_none_produces_list_string(self):
+        """list[str] | None should convert to [String!], not String."""
+        result = _python_type_to_graphql(list[str] | None, self.converter)
+        assert result == "[String!]", f"Expected '[String!]' but got '{result}'"
+
+    def test_optional_list_str_produces_list_string(self):
+        """Optional[list[str]] should convert to [String!], not String."""
+        result = _python_type_to_graphql(Optional[list[str]], self.converter)
+        assert result == "[String!]", f"Expected '[String!]' but got '{result}'"
+
+    def test_list_int_none_produces_list_int(self):
+        """list[int] | None should convert to [Int!], not String."""
+        result = _python_type_to_graphql(list[int] | None, self.converter)
+        assert result == "[Int!]", f"Expected '[Int!]' but got '{result}'"
+
+    def test_required_list_still_works(self):
+        """list[str] (without None) should still produce [String!]!."""
+        result = _python_type_to_graphql(list[str], self.converter)
+        assert result == "[String!]!"
+
+    # --- Full SDL generation ---
+
+    def test_sdl_optional_list_param_is_list_type(self):
+        """In generated SDL, list[str] | None param should appear as [String!], not String."""
+        generator = SDLGenerator([ItemForListBug])
+        sdl = generator.generate()
+
+        # The required list version should work correctly
+        assert "tags: [String!]!" in sdl, "Required list[str] should be [String!]!"
+
+        # The optional list version — THIS IS THE BUG
+        # Currently produces: tags: String
+        # Should produce:     tags: [String!]
+        assert "tags: [String!]" in sdl, (
+            f"Optional list[str] | None should produce '[String!]', not 'String'.\n"
+            f"SDL:\n{sdl}"
+        )
+
+    def test_sdl_optional_typing_list_param(self):
+        """Optional[list[str]] (typing module) should also produce [String!]."""
+        generator = SDLGenerator([ItemForListBug])
+        sdl = generator.generate()
+
+        # find the createWithOptionalTyping mutation
+        # its `tags` param should be [String!], not String
+        assert "tags: [String!]" in sdl, (
+            f"Optional[list[str]] should produce '[String!]' in SDL.\n"
+            f"SDL:\n{sdl}"
+        )
+
+    def test_sdl_optional_list_int_param(self):
+        """list[int] | None param should produce [Int!], not String."""
+        generator = SDLGenerator([ItemForListBug])
+        sdl = generator.generate()
+
+        assert "ids: [Int!]" in sdl, (
+            f"list[int] | None should produce '[Int!]' in SDL.\n"
+            f"SDL:\n{sdl}"
+        )
+
+    def test_list_of_optional_entity_produces_nullable_element_list(self):
+        """list[Entity | None] should produce [Entity], not [String!]."""
+        converter = TypeConverter({"ItemForListBug"})
+        result = _python_type_to_graphql(
+            list[ItemForListBug | None], converter, entity_names={"ItemForListBug"}
+        )
+        assert result == "[ItemForListBug]!", (
+            f"Expected '[ItemForListBug]!' but got '{result}'"
+        )
+
+    def test_list_of_optional_scalar_produces_nullable_element_list(self):
+        """list[str | None] should produce [String], not [String!]."""
+        result = _python_type_to_graphql(list[str | None], self.converter)
+        assert result == "[String]!", f"Expected '[String]!' but got '{result}'"

--- a/tests/test_optional_list_param.py
+++ b/tests/test_optional_list_param.py
@@ -1,4 +1,4 @@
-"""Regression test: list[str] | None parameter should produce [String], not String.
+"""Regression test: list[str] | None should produce [String!], not String.
 
 Bug: _python_type_to_graphql() checks `origin is list` before checking Optional.
 For `list[str] | None`, `get_origin()` returns UnionType, not list, so the list
@@ -16,7 +16,7 @@ from nexusx.sdl_generator import SDLGenerator, _python_type_to_graphql
 from nexusx.type_converter import TypeConverter
 
 
-# ── Entity with list[str] | None parameter ────────────────────────────
+# ── Entity with optional list parameters ───────────────────────────────
 
 
 class ItemForListBug(SQLModel):
@@ -53,17 +53,50 @@ class ItemForListBug(SQLModel):
         """Query with optional list[int]."""
         return []
 
+    @query
+    async def search_nullable_entities(
+        cls, ids: list[int | None] | None = None
+    ) -> list["ItemForListBug | None"]:
+        """Query with combined outer+inner optional list."""
+        return []
+
+
+def _extract_param_type(sdl: str, mutation_name: str, param_name: str) -> str | None:
+    """Extract the GraphQL type of a specific parameter from SDL.
+
+    Returns the type string (e.g. '[String!]!', [String!], String) or None.
+    """
+    target = f"{mutation_name}("
+    for line in sdl.splitlines():
+        line = line.strip()
+        if target in line:
+            # Find "paramName: <Type>" in the parameter list
+            needle = f"{param_name}: "
+            idx = line.find(needle)
+            if idx == -1:
+                continue
+            start = idx + len(needle)
+            rest = line[start:]
+            # Type ends at ',' or ')'
+            end = len(rest)
+            for ch in (",", ")"):
+                pos = rest.find(ch)
+                if pos != -1 and pos < end:
+                    end = pos
+            return rest[:end]
+    return None
+
 
 # ── Tests ─────────────────────────────────────────────────────────────
 
 
 class TestOptionalListParameterBug:
-    """list[T] | None should serialize to [T!], not String."""
+    """list[T] | None and list[T | None] should produce correct GraphQL types."""
 
     def setup_method(self) -> None:
         self.converter = TypeConverter(set())
 
-    # --- Direct type conversion ---
+    # --- Direct type conversion: outer Optional ---
 
     def test_list_str_none_produces_list_string(self):
         """list[str] | None should convert to [String!], not String."""
@@ -85,48 +118,10 @@ class TestOptionalListParameterBug:
         result = _python_type_to_graphql(list[str], self.converter)
         assert result == "[String!]!"
 
-    # --- Full SDL generation ---
-
-    def test_sdl_optional_list_param_is_list_type(self):
-        """In generated SDL, list[str] | None param should appear as [String!], not String."""
-        generator = SDLGenerator([ItemForListBug])
-        sdl = generator.generate()
-
-        # The required list version should work correctly
-        assert "tags: [String!]!" in sdl, "Required list[str] should be [String!]!"
-
-        # The optional list version — THIS IS THE BUG
-        # Currently produces: tags: String
-        # Should produce:     tags: [String!]
-        assert "tags: [String!]" in sdl, (
-            f"Optional list[str] | None should produce '[String!]', not 'String'.\n"
-            f"SDL:\n{sdl}"
-        )
-
-    def test_sdl_optional_typing_list_param(self):
-        """Optional[list[str]] (typing module) should also produce [String!]."""
-        generator = SDLGenerator([ItemForListBug])
-        sdl = generator.generate()
-
-        # find the createWithOptionalTyping mutation
-        # its `tags` param should be [String!], not String
-        assert "tags: [String!]" in sdl, (
-            f"Optional[list[str]] should produce '[String!]' in SDL.\n"
-            f"SDL:\n{sdl}"
-        )
-
-    def test_sdl_optional_list_int_param(self):
-        """list[int] | None param should produce [Int!], not String."""
-        generator = SDLGenerator([ItemForListBug])
-        sdl = generator.generate()
-
-        assert "ids: [Int!]" in sdl, (
-            f"list[int] | None should produce '[Int!]' in SDL.\n"
-            f"SDL:\n{sdl}"
-        )
+    # --- Direct type conversion: inner Optional ---
 
     def test_list_of_optional_entity_produces_nullable_element_list(self):
-        """list[Entity | None] should produce [Entity], not [String!]."""
+        """list[Entity | None] should produce [Entity]!, not [String!]."""
         converter = TypeConverter({"ItemForListBug"})
         result = _python_type_to_graphql(
             list[ItemForListBug | None], converter, entity_names={"ItemForListBug"}
@@ -136,6 +131,60 @@ class TestOptionalListParameterBug:
         )
 
     def test_list_of_optional_scalar_produces_nullable_element_list(self):
-        """list[str | None] should produce [String], not [String!]."""
+        """list[str | None] should produce [String]!, not [String!]."""
         result = _python_type_to_graphql(list[str | None], self.converter)
         assert result == "[String]!", f"Expected '[String]!' but got '{result}'"
+
+    def test_list_of_optional_int_produces_nullable_element_list(self):
+        """list[int | None] should produce [Int]!, not [String!]."""
+        result = _python_type_to_graphql(list[int | None], self.converter)
+        assert result == "[Int]!", f"Expected '[Int]!' but got '{result}'"
+
+    # --- Direct type conversion: combined outer+inner Optional ---
+
+    def test_list_of_optional_str_outer_none(self):
+        """list[str | None] | None should produce [String], not String."""
+        result = _python_type_to_graphql(list[str | None] | None, self.converter)
+        assert result == "[String]", f"Expected '[String]' but got '{result}'"
+
+    def test_list_of_optional_entity_outer_none(self):
+        """list[Entity | None] | None should produce [Entity], not String."""
+        converter = TypeConverter({"ItemForListBug"})
+        result = _python_type_to_graphql(
+            list[ItemForListBug | None] | None, converter, entity_names={"ItemForListBug"}
+        )
+        assert result == "[ItemForListBug]", (
+            f"Expected '[ItemForListBug]' but got '{result}'"
+        )
+
+    # --- Full SDL generation (precise extraction) ---
+
+    def test_sdl_required_list_param(self):
+        """Required list[str] param should produce [String!]!."""
+        sdl = SDLGenerator([ItemForListBug]).generate()
+        gql_type = _extract_param_type(sdl, "itemForListBugCreateWithRequiredTags", "tags")
+        assert gql_type == "[String!]!", f"Expected '[String!]!' but got '{gql_type}'"
+
+    def test_sdl_optional_list_param(self):
+        """list[str] | None param should produce [String!], not String."""
+        sdl = SDLGenerator([ItemForListBug]).generate()
+        gql_type = _extract_param_type(sdl, "itemForListBugCreateWithOptionalTags", "tags")
+        assert gql_type == "[String!]", f"Expected '[String!]' but got '{gql_type}'"
+
+    def test_sdl_optional_typing_list_param(self):
+        """Optional[list[str]] (typing module) should also produce [String!]."""
+        sdl = SDLGenerator([ItemForListBug]).generate()
+        gql_type = _extract_param_type(sdl, "itemForListBugCreateWithOptionalTyping", "tags")
+        assert gql_type == "[String!]", f"Expected '[String!]' but got '{gql_type}'"
+
+    def test_sdl_optional_list_int_param(self):
+        """list[int] | None param should produce [Int!], not String."""
+        sdl = SDLGenerator([ItemForListBug]).generate()
+        gql_type = _extract_param_type(sdl, "itemForListBugSearchOptionalInts", "ids")
+        assert gql_type == "[Int!]", f"Expected '[Int!]' but got '{gql_type}'"
+
+    def test_sdl_combined_optional_list_param(self):
+        """list[int | None] | None param should produce [Int], not String."""
+        sdl = SDLGenerator([ItemForListBug]).generate()
+        gql_type = _extract_param_type(sdl, "itemForListBugSearchNullableEntities", "ids")
+        assert gql_type == "[Int]", f"Expected '[Int]' but got '{gql_type}'"

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -931,3 +931,190 @@ class TestShouldTraverse:
         result = await Resolver().resolve(root)
 
         assert result.middle.leaf.source_name == "source_5"
+
+
+# ──────────────────────────────────────────────────────────
+# Test: post_default_handler — finalization hook (runs after all post_*)
+# ──────────────────────────────────────────────────────────
+
+
+class TestResolverPostDefaultHandler:
+    async def test_runs_after_all_post_methods(self):
+        """post_default_handler runs after every post_* at the same node,
+        so it can read fields those post_* methods populated."""
+
+        class Sprint(BaseModel):
+            total_tasks: int = 0
+            completed_tasks: int = 0
+            completion_rate: float = 0.0
+
+            def post_total_tasks(self):
+                return 10
+
+            def post_completed_tasks(self):
+                return 4
+
+            def post_default_handler(self):
+                self.completion_rate = (
+                    self.completed_tasks / self.total_tasks
+                    if self.total_tasks
+                    else 0.0
+                )
+
+        result = await Resolver().resolve(Sprint())
+        assert result.total_tasks == 10
+        assert result.completed_tasks == 4
+        assert result.completion_rate == 0.4
+
+    async def test_return_value_ignored_and_no_field_auto_assigned(self):
+        """The handler's return value is NOT auto-assigned to any field
+        (in particular, no spurious `default_handler` field is created),
+        and the body may set several fields manually."""
+
+        class Model(BaseModel):
+            a: int = 0
+            b: int = 0
+
+            def post_default_handler(self):
+                self.a = 1
+                self.b = 2
+                return "this return value must be ignored"
+
+        result = await Resolver().resolve(Model())
+        assert result.a == 1
+        assert result.b == 2
+        # No field named after the method is created.
+        assert not hasattr(result, "default_handler")
+
+    async def test_async_handler(self):
+        """async def post_default_handler is awaited correctly."""
+
+        class Model(BaseModel):
+            value: int = 0
+
+            async def post_default_handler(self):
+                await asyncio.sleep(0)
+                self.value = 42
+
+        result = await Resolver().resolve(Model())
+        assert result.value == 42
+
+    async def test_handler_reads_collector_populated_by_descendants(self):
+        """post_default_handler can read a Collector that descendants
+        populated via SendTo — recursion finishes before the handler runs."""
+
+        from typing import Annotated
+
+        from nexusx.context import Collector, SendTo
+
+        class Task(BaseModel):
+            id: Annotated[int, SendTo("task_ids")]
+
+        class Sprint(BaseModel):
+            tasks: list[Task] = []
+            task_ids: list[int] = []
+
+            def post_default_handler(self, collector=Collector("task_ids")):
+                self.task_ids = sorted(collector.values())
+
+        sprint = Sprint(tasks=[Task(id=3), Task(id=1), Task(id=2)])
+        result = await Resolver().resolve(sprint)
+        assert result.task_ids == [1, 2, 3]
+
+    async def test_handler_with_context(self):
+        """The context parameter is injected from Resolver(context=...)."""
+
+        class Model(BaseModel):
+            label: str = ""
+
+            def post_default_handler(self, context=None):
+                if context is None:
+                    context = {}
+                self.label = context.get("env", "unknown")
+
+        result = await Resolver(context={"env": "prod"}).resolve(Model())
+        assert result.label == "prod"
+
+    async def test_handler_with_parent(self):
+        """The parent parameter references the direct parent node."""
+
+        class Child(BaseModel):
+            parent_name: str = ""
+
+            def post_default_handler(self, parent=None):
+                self.parent_name = getattr(parent, "name", "?") if parent else "?"
+
+        class Parent(BaseModel):
+            name: str
+            child: Child
+
+        result = await Resolver().resolve(
+            Parent(name="Root", child=Child())
+        )
+        assert result.child.parent_name == "Root"
+
+    async def test_handler_with_ancestor_context(self):
+        """The ancestor_context parameter receives ExposeAs values."""
+
+        from typing import Annotated
+
+        from nexusx.context import ExposeAs
+
+        class Leaf(BaseModel):
+            tenant_label: str = ""
+
+            def post_default_handler(self, ancestor_context=None):
+                if ancestor_context is None:
+                    ancestor_context = {}
+                self.tenant_label = f"tenant={ancestor_context.get('tenant')}"
+
+        class Middle(BaseModel):
+            leaf: Leaf
+
+        class Root(BaseModel):
+            tenant: Annotated[str, ExposeAs("tenant")] = "acme"
+            middle: Middle
+
+        result = await Resolver().resolve(
+            Root(tenant="acme", middle=Middle(leaf=Leaf()))
+        )
+        assert result.middle.leaf.tenant_label == "tenant=acme"
+
+    async def test_handler_only_class_still_executes(self):
+        """A child node whose ONLY hook is post_default_handler must still
+        be traversed (regression: _compute_should_traverse must count it)."""
+
+        class Child(BaseModel):
+            name: str
+            processed: bool = False
+
+            def post_default_handler(self):
+                self.processed = True
+
+        class Parent(BaseModel):
+            child: Child
+
+        result = await Resolver().resolve(Parent(child=Child(name="x")))
+        assert result.child.processed is True
+
+    async def test_handler_runs_after_post_on_every_node_at_level(self):
+        """When multiple sibling nodes each have post_* + post_default_handler,
+        every node's handler runs after that node's post_* — independent of
+        ordering across siblings."""
+
+        class Counter(BaseModel):
+            n: int
+            doubled: int = 0
+            quadrupled: int = 0
+
+            def post_doubled(self):
+                return self.n * 2
+
+            def post_default_handler(self):
+                # reads the post_doubled value written moments ago
+                self.quadrupled = self.doubled * 2
+
+        root = [Counter(n=1), Counter(n=5), Counter(n=10)]
+        result = await Resolver().resolve(root)
+        assert [r.doubled for r in result] == [2, 10, 20]
+        assert [r.quadrupled for r in result] == [4, 20, 40]

--- a/tests/test_sdl_generator.py
+++ b/tests/test_sdl_generator.py
@@ -271,10 +271,9 @@ class TestPythonTypeToGraphql:
         """Test converting list[Optional[int]] type.
 
         Optional inside list is detected, element is nullable (no !).
-        Falls back to String since int|None doesn't map to a scalar directly.
         """
         result = _python_type_to_graphql(list[int | None], self.converter)
-        assert result == "[String]!"
+        assert result == "[Int]!"
 
     def test_list_str(self) -> None:
         """Test converting list[str] type."""

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -12,6 +12,7 @@ from nexusx.context import scan_expose_fields
 from nexusx.subset import (
     SUBSET_REFERENCE,
     DefineSubset,
+    SubsetConfig,
     get_subset_source,
 )
 from tests.conftest import FixtureSprint, FixtureTask, FixtureUser, get_test_session_factory
@@ -125,16 +126,20 @@ class TestDefineSubsetFK:
         assert "author_id" in data
         assert data["author_id"] == 42
 
-    def test_fk_not_auto_included_when_not_in_fields(self):
-        """FK fields NOT in fields list are NOT auto-included.
-        Users who need DataLoader key resolution must declare FK fields explicitly.
+    def test_fk_auto_included_when_not_in_fields(self):
+        """FK fields NOT in fields list are auto-included (with exclude=True)
+        so Resolver can use them as DataLoader keys for relationship loading.
         """
 
         class PostSummary(DefineSubset):
             __subset__ = (SamplePost, ("id", "title"))
 
-        # FK is NOT auto-included
-        assert "author_id" not in PostSummary.model_fields
+        # FK is auto-included but excluded from serialization
+        assert "author_id" in PostSummary.model_fields
+        dto = PostSummary(id=1, title="Hello")
+        assert dto.author_id is None
+        dumped = dto.model_dump()
+        assert "author_id" not in dumped
 
 
 # ──────────────────────────────────────────────────────────
@@ -1039,10 +1044,76 @@ class TestFKFieldHandling:
         assert dto.owner_id == 5
 
     def test_fk_field_not_in_fields_excluded(self):
-        """FK fields not in __subset__ should not appear."""
+        """FK fields not in __subset__ should not appear in serialized output."""
         from tests.conftest import FixtureTask
 
         class TaskDTO(DefineSubset):
             __subset__ = (FixtureTask, ("id", "title"))
 
+        # FK should be auto-included for Resolver but excluded from serialization
+        assert "owner_id" in TaskDTO.model_fields
+        dto = TaskDTO(id=1, title="T", owner_id=5)
+        assert dto.owner_id == 5
+        dumped = dto.model_dump()
+        assert "owner_id" not in dumped
+        assert dumped["title"] == "T"
+
+    def test_fk_auto_included_for_resolver(self):
+        """FK fields should be auto-included and excluded from serialization,
+        mirroring PK auto-inject behavior, so Resolver can use them as DataLoader keys."""
+
+        class TaskDTO(DefineSubset):
+            __subset__ = (FixtureTask, ("id", "title"))
+
+        # FK fields auto-included
+        assert "sprint_id" in TaskDTO.model_fields
+        assert "owner_id" in TaskDTO.model_fields
+
+        dto = TaskDTO(id=1, title="My Task", sprint_id=10, owner_id=20)
+        assert dto.sprint_id == 10
+        assert dto.owner_id == 20
+
+        # But excluded from serialization
+        dumped = dto.model_dump()
+        assert "sprint_id" not in dumped
+        assert "owner_id" not in dumped
+        assert dumped["title"] == "My Task"
+
+    def test_fk_auto_excluded_with_explicit_fields(self):
+        """FK auto-include should work with SubsetConfig + excluded_fields too."""
+        from tests.conftest import FixtureTask
+
+        class TaskDTO(DefineSubset):
+            __subset__ = SubsetConfig(
+                kls=FixtureTask,
+                fields=["id", "title"],
+            )
+
+        assert "owner_id" in TaskDTO.model_fields
+        dto = TaskDTO(id=1, title="T", owner_id=5)
+        assert dto.owner_id == 5
+        assert "owner_id" not in dto.model_dump()
+
+    def test_omit_fk_without_relationship_allowed(self):
+        """Omitting a FK is fine when no relationship field depends on it."""
+
+        class TaskDTO(DefineSubset):
+            __subset__ = SubsetConfig(
+                kls=FixtureTask, omit_fields=["owner_id"],
+            )
+
         assert "owner_id" not in TaskDTO.model_fields
+
+    def test_omit_fk_with_relationship_raises(self):
+        """Omitting a FK that a relationship field needs should raise ValueError."""
+        import pytest
+
+        class OwnerDTO(DefineSubset):
+            __subset__ = (FixtureUser, ("id", "name"))
+
+        with pytest.raises(ValueError, match="Cannot omit FK field 'owner_id'"):
+            class BadDTO(DefineSubset):
+                __subset__ = SubsetConfig(
+                    kls=FixtureTask, omit_fields=["owner_id"],
+                )
+                owner: OwnerDTO | None = None

--- a/tests/test_use_case_router.py
+++ b/tests/test_use_case_router.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from typing import Annotated
 
 import pytest
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
+from starlette.requests import Request
 
 from nexusx.decorator import mutation, query
 from nexusx.use_case.business import UseCaseService
@@ -347,3 +348,110 @@ class TestOpenAPI:
         user_path = schema["paths"].get("/api/user_service/list_users", {})
         if "post" in user_path:
             assert "UserService" in user_path["post"].get("tags", [])
+
+
+# ──────────────────────────────────────────────────
+# Tests: Extensibility (dependencies, route_options, router_kwargs)
+# ──────────────────────────────────────────────────
+
+
+class TestRouterExtensibility:
+    def test_router_dependencies_applied_to_all_routes(self):
+        """Router-level dependencies are enforced on every route."""
+        async def require_auth(request: Request) -> None:
+            if request.headers.get("X-Auth") != "secret":
+                raise HTTPException(status_code=403, detail="Forbidden")
+
+        config = UseCaseAppConfig(name="test", services=[PingService])
+        router = create_router(config, dependencies=[Depends(require_auth)])
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        # Without auth header → 403
+        response = client.post("/api/ping_service/ping")
+        assert response.status_code == 403
+
+        # With auth header → 200
+        response = client.post("/api/ping_service/ping", headers={"X-Auth": "secret"})
+        assert response.status_code == 200
+        assert response.json() == "pong"
+
+    def test_route_options_status_code(self):
+        """route_options can override status_code for a specific route."""
+        config = UseCaseAppConfig(name="test", services=[PingService])
+        router = create_router(
+            config,
+            route_options={
+                "PingService.ping": {"status_code": 201},
+            },
+        )
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.post("/api/ping_service/ping")
+        assert response.status_code == 201
+
+    def test_route_options_per_route_dependencies(self):
+        """Per-route dependencies only affect the targeted route."""
+        async def require_admin(request: Request) -> None:
+            if request.headers.get("X-Admin") != "yes":
+                raise HTTPException(status_code=403, detail="Admin only")
+
+        config = UseCaseAppConfig(name="test", services=[UserService, PingService])
+        router = create_router(
+            config,
+            route_options={
+                "UserService.create_user": {
+                    "dependencies": [Depends(require_admin)],
+                },
+            },
+        )
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        # create_user without admin → 403
+        response = client.post(
+            "/api/user_service/create_user",
+            json={"name": "X", "email": "x@test.com"},
+        )
+        assert response.status_code == 403
+
+        # list_users is unaffected → 200
+        response = client.post("/api/user_service/list_users")
+        assert response.status_code == 200
+
+        # ping is unaffected → 200
+        response = client.post("/api/ping_service/ping")
+        assert response.status_code == 200
+
+    def test_router_kwargs_passthrough(self):
+        """**router_kwargs are forwarded to APIRouter constructor."""
+        config = UseCaseAppConfig(name="test", services=[PingService])
+        # Pass deprecated=True through router_kwargs
+        router = create_router(config, deprecated=True)
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        # Route still works
+        response = client.post("/api/ping_service/ping")
+        assert response.status_code == 200
+
+        # Deprecated flag appears in OpenAPI schema
+        schema = client.get("/openapi.json").json()
+        ping_op = schema["paths"]["/api/ping_service/ping"]["post"]
+        assert ping_op.get("deprecated") is True
+
+    def test_backward_compatible_no_new_args(self):
+        """Existing call sites with no new arguments still work."""
+        config = UseCaseAppConfig(name="test", services=[UserService])
+        router = create_router(config)
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        response = client.post("/api/user_service/list_users")
+        assert response.status_code == 200

--- a/uv.lock
+++ b/uv.lock
@@ -1221,7 +1221,7 @@ wheels = [
 
 [[package]]
 name = "nexusx"
-version = "2.9.1"
+version = "2.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiodataloader" },

--- a/uv.lock
+++ b/uv.lock
@@ -1221,7 +1221,7 @@ wheels = [
 
 [[package]]
 name = "nexusx"
-version = "2.9.0"
+version = "2.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiodataloader" },


### PR DESCRIPTION
## Summary
- Add `dependencies` param for router-level auth/rate-limiting
- Add `route_options` dict for per-route overrides (`status_code`, `dependencies`, `response_model`, etc.)
- Add `**router_kwargs` passthrough to `APIRouter()` constructor
- 5 new tests, fully backward compatible

## Test plan
- [x] `uv run pytest tests/test_use_case_router.py -v` — 28/28 passed
- [x] `uv run ruff check src/nexusx/use_case/router.py` — clean
- [x] `uv run mypy src/nexusx/use_case/router.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)